### PR TITLE
Check CCPA ads after page reload

### DIFF
--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -30,6 +30,22 @@ const checkPage = async function (URL) {
     //click Do not sell my information
     const frame = page.frames().find(f => f.url().startsWith('https://ccpa-notice.sp-prod.net'));
     await frame.click('button[title="Do not sell my personal information"]');
+
+    // Reload page
+    const reloadResponse = await page.reload({
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+    if (!reloadResponse) {
+      throw "Failed to refresh page!";
+    }
+
+    // Check top-above-nav on page after clicking do not sell and then reloading
+    await page.waitForSelector(
+      ".ad-slot--top-above-nav .ad-slot__content iframe"
+    );
+
+    log.info("Ads on page after do-not-sell and reload");
 };
 
 const pageLoadBlueprint = async function () {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add an additional step to the CCPA canary that checks for the presence of the top-above-nav selector after:
 1. The "do not sell" button has been clicked.
 2. A page reload

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

This is currently running under a `commercial_cmp_test` canary in us-west-1. When this is merged this will be removed and replace `commercial_cmp_ccpa` (currently updated via the manual method as described in the README).

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We should be able to detect any future problems with ads loading after a user has clicked the "do not sell" in the CCPA banner.
