### PR TITLE
Add more comprehensive checks

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,7 +1,53 @@
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
 
-const checkPage = async function (URL) {
+const checkArticle = async function (URL) {
+	// Load article
+	let page = await synthetics.getPage();
+
+	const response = await page.goto(URL, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!response) {
+		throw 'Failed to load page!';
+	}
+
+	//If the response status code is not a 2xx success code
+	if (response.status() < 200 || response.status() > 299) {
+		throw 'Failed to load page!';
+	}
+
+	// Check ads have loaded
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	// Clear cookies
+	const client = await page.target().createCDPSession();
+	await client.send('Network.clearBrowserCookies');
+
+	// Reload page
+	const reloadResponse = await page.reload({
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!reloadResponse) {
+		throw 'Failed to refresh page!';
+	}
+
+	// Check ads load before banner is interacted with
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	// Check CMP on page
+	await page.waitForSelector('[id*="sp_message_container"]');
+
+	log.info('Article follow on check complete');
+};
+
+const checkPage = async function (URL, nextURL) {
 	log.info(`Checking Page URL ${URL}`);
 
 	let page = await synthetics.getPage();
@@ -18,30 +64,60 @@ const checkPage = async function (URL) {
 		throw 'Failed to load page!';
 	}
 
+	//If the response status code is not a 2xx success code
+	if (response.status() < 200 || response.status() > 299) {
+		throw 'Failed to load page!';
+	}
+
+	//Ads loaded before interacting with CMP
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
 	// wait for CMP
 	await page.waitForSelector('[id*="sp_message_container"]');
 	log.info('CMP loaded');
 
-	//await synthetics.takeScreenshot('loaded', 'loaded');
-
-	//Ads loaded before interacting with CMP
-	// Uncomment when AUS house ads are fixed
-	//await page.waitForSelector('.ad-slot--top-above-nav .ad-slot__content iframe');
-
-	//click OK
+	//click Do not sell my information
 	const frame = page
 		.frames()
 		.find((f) => f.url().startsWith('https://ccpa-notice.sp-prod.net'));
-	await page.waitFor(2000);
 	await frame.click('button[title="Continue"]');
+
+	await page.waitFor(2000);
+
+	// Reload page
+	const reloadResponse = await page.reload({
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!reloadResponse) {
+		throw 'Failed to refresh page!';
+	}
+
+	// Check top-above-nav on page after clicking do not sell and then reloading
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	// Check another article after this page (initially without clearing cookies)
+	if (nextURL !== undefined) {
+		await checkArticle(nextURL);
+	}
 };
 
 const pageLoadBlueprint = async function () {
-	// Check Front
-	await checkPage('https://www.theguardian.com');
+	// Check front as first navigation
+	// After front check make sure ads load when viewing an article
+	await checkPage(
+		'https://www.theguardian.com/us',
+		'https://www.theguardian.com/us-news/2021/jul/05/gray-wolves-wisconsin-hunting-population',
+	);
 
-	// Check Article
-	// await checkPage("https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake");
+	// Check Article as first navigation
+	await checkPage(
+		'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake',
+	);
 };
 
 exports.handler = async () => {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -1,7 +1,53 @@
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
 
-const checkPage = async function (URL) {
+const checkArticle = async function (URL) {
+	// Load article
+	let page = await synthetics.getPage();
+
+	const response = await page.goto(URL, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!response) {
+		throw 'Failed to load page!';
+	}
+
+	//If the response status code is not a 2xx success code
+	if (response.status() < 200 || response.status() > 299) {
+		throw 'Failed to load page!';
+	}
+
+	// Check ads have loaded
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	// Clear cookies
+	const client = await page.target().createCDPSession();
+	await client.send('Network.clearBrowserCookies');
+
+	// Reload page
+	const reloadResponse = await page.reload({
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!reloadResponse) {
+		throw 'Failed to refresh page!';
+	}
+
+	// Check ads load before banner is interacted with
+	await page.waitForSelector(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	// Check CMP on page
+	await page.waitForSelector('[id*="sp_message_container"]');
+
+	log.info('Article follow on check complete');
+};
+
+const checkPage = async function (URL, nextURL) {
 	log.info(`Checking Page URL ${URL}`);
 
 	let page = await synthetics.getPage();
@@ -38,6 +84,8 @@ const checkPage = async function (URL) {
 		.find((f) => f.url().startsWith('https://ccpa-notice.sp-prod.net'));
 	await frame.click('button[title="Do not sell my personal information"]');
 
+	await page.waitFor(2000);
+
 	// Reload page
 	const reloadResponse = await page.reload({
 		waitUntil: 'domcontentloaded',
@@ -52,14 +100,21 @@ const checkPage = async function (URL) {
 		'.ad-slot--top-above-nav .ad-slot__content iframe',
 	);
 
-	log.info('Ads on page after do-not-sell and reload');
+	// Check another article after this page (initially without clearing cookies)
+	if (nextURL !== undefined) {
+		await checkArticle(nextURL);
+	}
 };
 
 const pageLoadBlueprint = async function () {
-	// Check Front
-	await checkPage('https://www.theguardian.com/us');
+	// Check front as first navigation
+	// After front check make sure ads load when viewing an article
+	await checkPage(
+		'https://www.theguardian.com/us',
+		'https://www.theguardian.com/us-news/2021/jul/05/gray-wolves-wisconsin-hunting-population',
+	);
 
-	// Check Article
+	// Check Article as first navigation
 	await checkPage(
 		'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake',
 	);


### PR DESCRIPTION
## What does this change?

Add more comprehensive checks to the canaries. This checks involve:
-  Performing a follow-up checking on an article without deleting cookies (for both CCPA and TCFv2)
- Bringing AUS checks in line with this new CCPA version.

Note this PR doesn't include checking banners are clicked after clicking buttons in the banner.

## Why

Attempt to detect more problems that could arise via canary than we were previously.