### PR TITLE
Add checks that CMP/ads are not displayed at certain points

### DIFF
--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -1,6 +1,19 @@
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
 
+const checkCMPIsHidden = async (page) => {
+	const display = await page.evaluate(
+		`window.getComputedStyle(document.querySelector('[id*=\\"sp_message_container\\"]')).getPropertyValue('display')`,
+	);
+
+	// Use `!=` rather than `!==` here because display is a DOMString type
+	if (display != 'none') {
+		throw Error('CMP still present on page');
+	}
+
+	log.info('CMP hidden on page');
+};
+
 const checkArticle = async function (URL) {
 	// Load article
 	let page = await synthetics.getPage();
@@ -84,7 +97,10 @@ const checkPage = async function (URL, nextURL) {
 		.find((f) => f.url().startsWith('https://ccpa-notice.sp-prod.net'));
 	await frame.click('button[title="Do not sell my personal information"]');
 
-	await page.waitFor(2000);
+	await page.waitFor(5000);
+
+	// Check CMP is now hidden on page
+	await checkCMPIsHidden(page);
 
 	// Reload page
 	const reloadResponse = await page.reload({

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -1,6 +1,41 @@
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
 
+const checkAdsDidNotLoad = async (page) => {
+	const frame = await page.$(
+		'.ad-slot--top-above-nav .ad-slot__content iframe',
+	);
+
+	log.info('Top above nav frame on page:', frame !== null);
+
+	if (frame !== null) {
+		throw Error('Top above nav frame present on page');
+	}
+};
+
+const checkCMPDidNotLoad = async (page) => {
+	const spMessageContainer = await page.$('[id*="sp_message_container"]');
+
+	log.info('sp_message_container on page:', spMessageContainer !== null);
+
+	if (spMessageContainer !== null) {
+		throw Error('CMP present on page');
+	}
+};
+
+const checkCMPIsHidden = async (page) => {
+	const display = await page.evaluate(
+		`window.getComputedStyle(document.querySelector('[id*=\\"sp_message_container\\"]')).getPropertyValue('display')`,
+	);
+
+	// Use `!=` rather than `!==` here because display is a DOMString type
+	if (display != 'none') {
+		throw Error('CMP still present on page');
+	}
+
+	log.info('CMP hidden on page');
+};
+
 const checkArticle = async function (URL) {
 	log.info(`Checking Article URL ${URL}`);
 
@@ -32,6 +67,9 @@ const checkArticle = async function (URL) {
 	if (!reloadResponse) {
 		throw 'Failed to refresh page!';
 	}
+
+	// Check no ads load
+	await checkAdsDidNotLoad(page);
 
 	// Check banner is shown
 	await page.waitForSelector('[id*="sp_message_container"]');
@@ -71,6 +109,10 @@ const checkPage = async function (URL) {
 	await page.waitFor(1000);
 	await frame.click('button[title="Yes, I’m happy"]');
 
+	await page.waitFor(5000);
+
+	await checkCMPIsHidden(page);
+
 	//ads are loaded
 	await page.waitForSelector(
 		'.ad-slot--top-above-nav .ad-slot__content iframe',
@@ -89,6 +131,9 @@ const checkPage = async function (URL) {
 	await page.waitForSelector(
 		'.ad-slot--top-above-nav .ad-slot__content iframe',
 	);
+
+	// TODO
+	await checkCMPDidNotLoad(page);
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -132,7 +132,7 @@ const checkPage = async function (URL) {
 		'.ad-slot--top-above-nav .ad-slot__content iframe',
 	);
 
-	// TODO
+	// Check CMP is not present on page after reload
 	await checkCMPDidNotLoad(page);
 };
 


### PR DESCRIPTION
## What does this change?

Adds the following checks to the canaries:
- On CCPA, check the CMP banner is hidden after pressing "Do not sell my information"
- On TCFv2, check top-above-nav doesn't load before pressing "Yes I'm happy" in banner.
- On TCFv2, check the CMP banner is hidden after pressing "Yes I'm happy"
- On TCFv2, check the CMP isn't loaded after a page reload (without clearing cookies / local storage)

## Why

Hopefully we can detect more CMP / ad loading bugs by checking that ads/CMP aren't displayed at certain points.