### PR TITLE
Increase timeout to load TCFv2 consent banner iframe from 1s to 5s

### DIFF
--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -102,11 +102,13 @@ const checkPage = async function (URL) {
 	await page.waitForSelector('[id*="sp_message_container"]');
 	log.info('CMP loaded');
 
+	// Wait for iframe to load into sp_message_container
+	await page.waitFor(5000);
+
 	// Click on Yes I'm happy
 	const frame = page
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
-	await page.waitFor(1000);
 	await frame.click('button[title="Yes, I’m happy"]');
 
 	await page.waitFor(5000);


### PR DESCRIPTION
## What does this change?

For the TCFv2 canary, wait 5 seconds instead of 1 for the iframe to be loaded into the SourcePoint message container. Additionally, move the wait from before we attempt to click the button to before we attempt to select the iframe from the page.

## How can we measure success?

This change was made as the TCFv2 canary deployed in the Canada region was timing out waiting for the consent banner iframe to load onto the page. Hence we increase the timeout to ensure we give it enough time to load on the page.