### PR TITLE
Fix TCF Canaries following Sourcepoint cookie banner change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ These checks run every minute in 4 different regions, Canada, Australia, the US,
 
 They're hosted on the frontend AWS account.
 
-The code for the canaries is here:
-<https://github.com/guardian/aws-canaries>
-
 Alert notifications are sent to commercial.canaries@guardian.co.uk, and another notification on recovery.
 
 - On **failure** the email subjects look like this: `ALARM: "US CMP failed" in US West (N. California)`
@@ -16,7 +13,7 @@ Alert notifications are sent to commercial.canaries@guardian.co.uk, and another 
 When you are logged into the AWS account for frontend via [Janus](https://janus.gutools.co.uk/) you can see more detailed status information or the raw output from the Lambda run that failed.
 A [combined dashboard of the status checks](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Commercial-Canaries;start=PT3H) is also available.
 
-You can also find it the status by logging into the frontend AWS console, and navigating to CloudWatch > Application Monitoring > Synthetics Canaries, although this is region-by-region and you'll switch regions at the top of the screen to see each one.
+You can also find it the status by logging into the frontend AWS console, and navigating to CloudWatch > Application Monitoring > Synthetics Canaries, although this is region-by-region and you'll need to switch regions at the top of the screen to see each one.
 
 
 ### Requirements
@@ -41,15 +38,11 @@ You can also find it the status by logging into the frontend AWS console, and na
 11. Check ads load before banner is interacted with
 12. check the banner shows
 
-**Canada**
-
-Same as Ireland
-
 **Aus**
 
 Same as US, except we use the "Continue" banner button rather "Do not sell my information"
 
-**TCFv2 (Ireland and Canada)**
+**Ireland and Canada (TCFv2)**
 
 1. Load a front
 2. Check that _no_ ads load before banner is interacted with
@@ -67,18 +60,18 @@ Same as US, except we use the "Continue" banner button rather "Do not sell my in
 
 ### Manual Update
 
-There are currently 4 canary tests running that check the CMP is loaded successfully and ads are loaded at the right time in US, Canada, AUS and UK respectively.
+There are currently 4 canary tests running that check the CMP is loaded successfully and ads are loaded at the right time in Canada, Australia, the US, and Ireland.
 
-Note that US and Canada canaries currently use the same source file but are deployed as two separate canaries in two different regions. Even though Canada also operates under TCFV2 we use another canary to monitor this region separately as it has different possible failure modes, as ads are controlled by a third party.
+Login to AWS frontend via Janus. The code is run using Lambda, but since the relevant code is found in a [layer](https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html?icmpid=docs_lambda_help), you will need to navigate to Cloudwatch -> Synthetic Canaries to update the code. Select the relevant Canary, then select "Edit Canary".
 
-| File            | AWS Region     | Canary configuration name |
-| --------------- | -------------- | ------------------------- |
-| `src/cmp_tcfv2` | eu-west-1      | commercial_cmp_tcfv2      |
-| `src/cmp_ccpa`  | us-west-1      | commercial_cmp_us         |
-| `src/cmp_tcfv2` | ca-central-1   | commercial_cmp_ca         |
-| `src/cmp_aus`   | ap-southeast-2 | commercial_cmp_aus        |
+| Region          | File            | AWS Region     | Canary configuration name |
+| --------------- | --------------- | -------------- | ------------------------- |
+| Ireland         | `src/cmp_tcfv2` | eu-west-1      | commercial_cmp_tcfv2      |
+| US              | `src/cmp_ccpa`  | us-west-1      | commercial_cmp_us         |
+| Canada          | `src/cmp_tcfv2` | ca-central-1   | commercial_cmp_ca         |
+| Australia       | `src/cmp_aus`   | ap-southeast-2 | commercial_cmp_aus        |
 
-Login to AWS frontend via Janus, and replace the code via the built in Script Editor
+Note that US and Canada canaries currently use the same source file, but are deployed as two separate canaries in two different regions. Even though Canada also operates under [TCFV2](https://iabeurope.eu/tcf-2-0/) we use another canary to monitor this region separately as it has different possible failure modes, as ads are controlled by a third party.
 
 ### Automatic Update
 

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,17 +1,38 @@
 const synthetics = require('Synthetics');
 const log = require('SyntheticsLogger');
 
+// Initial timestamp used in logging
+const startTime = new Date().getTime();
+const getTimeSinceStart = () => new Date().getTime() - startTime
+
+// Random ID used in logger below
+const runID = Math.floor(Math.random()*10000000000).toString(36);
+
+const taggedLogger = (message) => {
+	log.info(`GUCanaryRun:${runID}:${getTimeSinceStart()}ms: ${message}`);
+}
+
 const checkCMPIsHidden = async (page) => {
-	const display = await page.evaluate(
-		`window.getComputedStyle(document.querySelector('[id*=\\"sp_message_container\\"]')).getPropertyValue('display')`,
-	);
+	taggedLogger(`Checking CMP is Hidden: Start`);
+
+	const getSpMessageDisplayProperty = function () {
+		const element = document.querySelector(
+			'[id*="sp_message_container"]',
+		);
+		if (element) {
+			const computedStyle = window.getComputedStyle(element);
+			return computedStyle.getPropertyValue('display');
+		}
+	};
+
+	const display = await page.evaluate(getSpMessageDisplayProperty);
 
 	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display != 'none') {
+	if (display && display != 'none') {
 		throw Error('CMP still present on page');
 	}
 
-	log.info('CMP hidden on page');
+	taggedLogger('CMP hidden or removed from page');
 };
 
 const checkArticle = async function (URL) {
@@ -57,11 +78,11 @@ const checkArticle = async function (URL) {
 	// Check CMP on page
 	await page.waitForSelector('[id*="sp_message_container"]');
 
-	log.info('Article follow on check complete');
+	taggedLogger('Article follow on check complete');
 };
 
 const checkPage = async function (URL, nextURL) {
-	log.info(`Checking Page URL ${URL}`);
+	taggedLogger(`Checking Page URL ${URL}`);
 
 	let page = await synthetics.getPage();
 
@@ -89,7 +110,7 @@ const checkPage = async function (URL, nextURL) {
 
 	// wait for CMP
 	await page.waitForSelector('[id*="sp_message_container"]');
-	log.info('CMP loaded');
+	taggedLogger('CMP loaded');
 
 	//click Do not sell my information
 	const frame = page


### PR DESCRIPTION
## Background

Sourcepoint, the provider of the main cookie banner, have changed the way they handle acceptance of the banner. They used to hide the banner in the DOM, but now they remove the banner from the DOM. This has meant that the canary we use to check that ads are loading correctly, has stopped working. This is because the canary checks that when the cookie banner is accepted, the banner is hidden.

## What does this PR change?

- Change the check that the banner is hidden. We now check whether the banner is hidden or removed from the DOM. We only care that the user can no longer see the banner after accepting cookies, so it does not matter to us whether Sourcepoint choose to hide the banner or remove it.
- Added some extra logging, so that is easier to see what log messages are generated by us, and how much time has elapsed between these messages.
- Updated README.

## How to test

- Check that the canaries are no longer failing with the message: _"ERROR Canary error: Error: Evaluation failed: TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'."_
