### PR TITLE
Update synthetics runtime version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Canaries are hosted in the following regions: Ireland, Canada, the US and Austra
 
 ## Configuration
 
-A canary will initiate a run every two minutes. 
+A canary will initiate a run every two minutes.
 
-| Region          | File            | AWS Region     | Canary name               | Banner button text                  |
-| --------------- | --------------- | -------------- | ------------------------- | ----------------------------------- |
-| Ireland         | `src/cmp_tcfv2` | eu-west-1      | commercial_cmp_uk         | Yes, I’m happy                      |
-| Canada          | `src/cmp_tcfv2` | ca-central-1   | commercial_cmp_ca         | Yes, I’m happy                      |
-| US              | `src/cmp_ccpa`  | us-west-1      | commercial_cmp_us         | Do not sell my personal information |
-| Australia       | `src/cmp_aus`   | ap-southeast-2 | commercial_cmp_aus        | Continue                            |
+| Region    | AWS Region     | Canary name        | Banner button text                  |
+| --------- | -------------- | ------------------ | ----------------------------------- |
+| Ireland   | eu-west-1      | commercial_cmp_uk  | Yes, I’m happy                      |
+| Canada    | ca-central-1   | commercial_cmp_ca  | Yes, I’m happy                      |
+| US        | us-west-1      | commercial_cmp_us  | Do not sell my personal information |
+| Australia | ap-southeast-2 | commercial_cmp_aus | Continue                            |
 
 The Ireland and Canada canaries use the same source file as they both operate under [TCFV2](https://iabeurope.eu/tcf-2-0/). However, we monitor these regions separately as there are different possible failure modes since ads are controlled by a third party.
 
@@ -22,50 +22,51 @@ The US and Australia canaries have very similar source files, since the relation
 In Ireland and Canada we must not load ads before the CMP is interacted with and consent is given, whereas in the US and Australia we can load ads on page load. Within the canary code we test the following:
 
 | Region    | On page load | Accept cookies | Clear cookies & refresh |
-| --------- |:------------:|:--------------:|:-----------------------:|
-| US        | Ads          | Ads            | Ads                     |
-| Australia | Ads          | Ads            | Ads                     |
-| Ireland   | No ads       | Ads            | No ads                  |
-| Canada    | No ads       | Ads            | No ads                  |
+| --------- | :----------: | :------------: | :---------------------: |
+| US        |     Ads      |      Ads       |           Ads           |
+| Australia |     Ads      |      Ads       |           Ads           |
+| Ireland   |    No ads    |      Ads       |         No ads          |
+| Canada    |    No ads    |      Ads       |         No ads          |
 
 ## Monitoring and notifications
 
 You can find the status of each canary by logging into the frontend AWS console and navigating to CloudWatch > Synthetics Canaries. You'll need to switch regions at the top of the screen to see each one. A [combined dashboard](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards:name=Commercial-Canaries) of the status checks is also available.
 
-If ads are not loading in a region, the team is informed via email by a CloudWatch Alarm which is sent to commercial.canaries@guardian.co.uk. Five consecutive failures are required to send an alarm. Another notification is sent on the first pass following five consecutive failures.
+If ads are not loading in a region, the team is informed via email by a CloudWatch Alarm which is sent to commercial.canaries@guardian.co.uk. Five consecutive failures are required to send an alarm. Another email is sent on the first pass following an alarm.
 
-- On **failure** the email subjects look like this: `ALARM: "US CMP failed" in US West (N. California)`
-- On **recovery** the email subject looks like this: `OK: "US CMP failed" in US West (N. California)`
+-   On **failure** the email subject is: `ALARM: "Commercial canary" in Asia Pacific (Sydney)`
+-   On **recovery** the email subject is: `OK: "Commercial canary" in Asia Pacific (Sydney)`
 
 When you are logged into the AWS account for frontend via [Janus](https://janus.gutools.co.uk/) you can see more detailed status information or the raw output from the Lambda run that failed.
 
 ## Debugging
 
-Login to AWS frontend via Janus. To find the canary in AWS: 
-- Ensure you are in the correct AWS region (`us-west-1`, `ap-southeast-2`, `eu-west-1` or `ca-central-1`)
-- Go to CloudWatch > Synthetics Canaries
-- Search for and select your canary. The canary looks like `commercial_cmp_us`
+Login to AWS frontend via Janus. To find the canary in AWS:
+
+-   Ensure you are in the correct AWS region (`us-west-1`, `ap-southeast-2`, `eu-west-1` or `ca-central-1`)
+-   Go to CloudWatch > Synthetics Canaries
+-   Search for and select your canary. The canary is named `comm_cmp_canary_prod`
 
 From here, you can see all the details relating to the canary and the recent runs. To see detailed logs, select Log groups from the sidebar and select your canary. At the current moment, we are experiencing infrequent and inconsistent failures; this does not indicate a serious problem with loading ads, but an inherent problem with testing ads via a headless browser.
 
 ## Requirements
 
-* [Node 14](https://nodejs.org/en/download/) ([nvm](https://github.com/nvm-sh/nvm))
-* [Yarn](https://classic.yarnpkg.com/en/docs/install/)
+-   [Node 14](https://nodejs.org/en/download/) ([nvm](https://github.com/nvm-sh/nvm))
+-   [Yarn](https://classic.yarnpkg.com/en/docs/install/)
 
 ## Development
 
-Canaries are located in the src folder. Create a new branch, make your changes to the code, then push your branch. A test canary that looks like `comm_cmp_us_test` will be updated with your code by a Github Action and Riffraff. To check the progress of the update in Riffraff, go to History and search for the project `frontend::commercial-canary-(us|uk|au|ca)`. The canary will be created in a stopped state, so you will need to click Actions -> Start to start a run.
+Canaries are located in the src folder. Create a new branch, make your changes to the code, then push your branch. A test canary is called `comm_cmp_canary_code` will be updated with your code by a Github Action and Riffraff. To check the progress of the update in Riffraff, go to History and search for the project `frontend::commercial-canaries`. The canary will be created in a stopped state, so you will need to click Actions -> Start to start a run.
 
 Alternatively, you can locate the test canary in the AWS console, edit the canary, paste your code over the existing code and save.
 
 ## Deploying
 
-Continuous deployment is set up using a combination of Github Actions and Riffraff. 
+Continuous deployment is set up using a combination of Github Actions and Riffraff.
 
 ### Process
 
-A push to the main branch will trigger the Github Action `deploy.yaml`, which runs the script `create-artifacts.sh` to zip up the lambda functions. These need to be zipped because AWS expects to find a zip file containing a template when creating a canary. Each zip file and CloudFormation template is uploaded to Riffraff using (actions-riff-raff)[https://github.com/guardian/actions-riff-raff]. Continuous deployment is set up in Riffraff for each AWS region. Riffraff will then upload the files to S3 and execute the CloudFormation script to update the necessary resources, including the canary code.
+A push to the main branch will trigger the Github Action `deploy.yaml`, which runs the script `create-artifacts.sh` to zip up the lambda functions. These need to be zipped because AWS expects to find a zip file containing a template when creating a canary. It will also run cdk commands which will run tests and generate the CloudFormation templates. Each zip file and CloudFormation template is uploaded to Riffraff using (actions-riff-raff)[https://github.com/guardian/actions-riff-raff]. Continuous deployment is set up in Riffraff for each AWS region. Riffraff will then upload the files to S3 and execute the CloudFormation script to update the necessary resources, including the canary code.
 
 ### Further information
 

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -9,11 +9,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-ap-southeast-2/canary/ap-southeast-2/comm_cmp_canary_code",
+              "-ap-southeast-2/CODE",
             ],
           ],
         },
@@ -107,6 +107,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-ap-southeast-2/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -227,11 +247,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-ap-southeast-2/canary/ap-southeast-2/comm_cmp_canary_prod",
+              "-ap-southeast-2/PROD",
             ],
           ],
         },
@@ -325,6 +345,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-ap-southeast-2/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -445,11 +485,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-ca-central-1/canary/ca-central-1/comm_cmp_canary_code",
+              "-ca-central-1/CODE",
             ],
           ],
         },
@@ -543,6 +583,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-ca-central-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -663,11 +723,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-ca-central-1/canary/ca-central-1/comm_cmp_canary_prod",
+              "-ca-central-1/PROD",
             ],
           ],
         },
@@ -761,6 +821,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-ca-central-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -881,11 +961,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-eu-west-1/canary/eu-west-1/comm_cmp_canary_code",
+              "-eu-west-1/CODE",
             ],
           ],
         },
@@ -979,6 +1059,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-eu-west-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -1099,11 +1199,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-eu-west-1/canary/eu-west-1/comm_cmp_canary_prod",
+              "-eu-west-1/PROD",
             ],
           ],
         },
@@ -1197,6 +1297,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-eu-west-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -1317,11 +1437,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-us-west-1/canary/us-west-1/comm_cmp_canary_code",
+              "-us-west-1/CODE",
             ],
           ],
         },
@@ -1415,6 +1535,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-us-west-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },
@@ -1535,11 +1675,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "s3://cw-syn-canary-",
+              "s3://cw-syn-results-",
               Object {
                 "Ref": "AWS::AccountId",
               },
-              "-us-west-1/canary/us-west-1/comm_cmp_canary_prod",
+              "-us-west-1/PROD",
             ],
           ],
         },
@@ -1633,6 +1773,26 @@ Object {
                       "",
                       Array [
                         "arn:aws:s3:::cw-syn-canary-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-us-west-1/*",
+                      ],
+                    ],
+                  },
+                },
+                Object {
+                  "Action": Array [
+                    "s3:PutObject",
+                    "s3:GetObject",
+                    "s3:GetBucketLocation",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:s3:::cw-syn-results-",
                         Object {
                           "Ref": "AWS::AccountId",
                         },

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -43,7 +43,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -261,7 +261,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -479,7 +479,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -697,7 +697,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -915,7 +915,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -1133,7 +1133,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -1351,7 +1351,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },
@@ -1569,7 +1569,7 @@ Object {
         "RunConfig": Object {
           "TimeoutInSeconds": 120,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.5",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
         "Schedule": Object {
           "Expression": "rate(2 minutes)",
         },

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -94,7 +94,7 @@ export class CommercialCanaries extends GuStack {
 			},
 			executionRoleArn: role.roleArn,
 			name: canaryName,
-			runtimeVersion: 'syn-nodejs-puppeteer-3.5',
+			runtimeVersion: 'syn-nodejs-puppeteer-3.6',
 			schedule: {
 				expression: 'rate(2 minutes)',
 			},

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -28,7 +28,8 @@ export class CommercialCanaries extends GuStack {
 
 		const email = 'commercial.canaries@guardian.co.uk';
 		const accountId = this.account;
-		const S3Bucket = `cw-syn-canary-${accountId}-${awsRegion}`;
+		const S3BucketCanary = `cw-syn-canary-${accountId}-${awsRegion}`;
+		const S3BucketResults = `cw-syn-results-${accountId}-${awsRegion}`;
 
 		// Limitation of max 21 characaters and lower case. Pattern: ^[0-9a-z_\-]+$
 		const canaryName = `comm_cmp_canary_${stage.toLocaleLowerCase()}`;
@@ -36,7 +37,12 @@ export class CommercialCanaries extends GuStack {
 		const policyDocument = new iam.PolicyDocument({
 			statements: [
 				new iam.PolicyStatement({
-					resources: [`arn:aws:s3:::${S3Bucket}/*`],
+					resources: [`arn:aws:s3:::${S3BucketCanary}/*`],
+					actions: ['s3:PutObject', 's3:GetObject', 's3:GetBucketLocation'],
+					effect: iam.Effect.ALLOW,
+				}),
+				new iam.PolicyStatement({
+					resources: [`arn:aws:s3:::${S3BucketResults}/*`],
 					actions: ['s3:PutObject', 's3:GetObject', 's3:GetBucketLocation'],
 					effect: iam.Effect.ALLOW,
 				}),
@@ -86,10 +92,10 @@ export class CommercialCanaries extends GuStack {
 		});
 
 		new synthetics.CfnCanary(this, 'Canary', {
-			artifactS3Location: `s3://${S3Bucket}/canary/${awsRegion}/${canaryName}`,
+			artifactS3Location: `s3://${S3BucketResults}/${stage.toUpperCase()}`,
 			code: {
 				handler: 'pageLoadBlueprint.handler',
-				s3Bucket: S3Bucket,
+				s3Bucket: S3BucketCanary,
 				s3Key: `${stage}/nodejs.zip`,
 			},
 			executionRoleArn: role.roleArn,


### PR DESCRIPTION
## What does this change?

1. Updates the synthetics runtime version to the latest.

1. We currently use an S3 bucket to store both canary code and logs for each region. The layout of the bucket is a bit confusing, so choose a new layout which makes it clear where the canary code lives and where the logs (artifacts) live.
We're going FROM:
`lambda: canary-cw-syn-canary-{accountId}-{region}`
`logs: canary-cw-syn-canary-{accountId}-{region}/{stage}`
TO:
`lambda: canary-cw-syn-canary-{accountId}-{region}/{stage}`
`logs: canary-cw-syn-results-{accountId}-{region}/{stage}`
Note that the four `canary-cw-syn-results-{accountId}-{region}` buckets already existed and are unused, which is why they have been repurposed for this.

1. Updates the README. This was out of date following the CDK changes.