### PR TITLE
Update CCPA Iframe URL

### DIFF
--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -38,7 +38,7 @@ const interactWithCMP = async (page) => {
 	logInfoMessage(`Clicking on "Do not sell my personal information" on CMP`);
 	const frame = page
 		.frames()
-		.find((f) => f.url().startsWith('https://ccpa-notice.sp-prod.net'));
+		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Do not sell my personal information"]');
 }
 


### PR DESCRIPTION
The update to the SP API means the CCPA message is now served from the `sourcepoint.theguardian.com` instead of the old `ccpa-notice.sp-prod.net`. 

This change ensures the ccpa message iframe is still correctly located

