### PR TITLE
Ensure the browser is closed for the AUS/US canaries

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -72,7 +72,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -315,7 +315,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -558,7 +558,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -801,7 +801,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -1044,7 +1044,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -1287,7 +1287,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -1530,7 +1530,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },
@@ -1773,7 +1773,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "3",
+            "Value": "4",
           },
         ],
       },

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -118,7 +118,7 @@ export class CommercialCanaries extends GuStack {
 				},
 				{
 					key: 'version',
-					value: '3',
+					value: '4',
 				},
 			],
 		});

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -132,28 +132,35 @@ const loadPage = async (page, url) => {
 const checkPage = async (url) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
-	const browser = await makeNewBrowser();
-	const page = await browser.newPage();
+	let browser = null;
+	try {
+		const browser = await makeNewBrowser();
+		const page = await browser.newPage();
 
-	// Clear cookies before starting testing, to ensure the CMP is displayed.
-	const client = await page.target().createCDPSession();
-	await clearCookies(client);
+		// Clear cookies before starting testing, to ensure the CMP is displayed.
+		const client = await page.target().createCDPSession();
+		await clearCookies(client);
 
-	await loadPage(page, url);
+		await loadPage(page, url);
 
-	await checkTopAdHasLoaded(page);
+		await checkTopAdHasLoaded(page);
 
-	await checkCMPIsOnPage(page);
+		await checkCMPIsOnPage(page);
 
-	await interactWithCMP(page);
+		await interactWithCMP(page);
 
-	await checkCMPIsNotVisible(page);
+		await checkCMPIsNotVisible(page);
 
-	await reloadPage(page);
+		await reloadPage(page);
 
-	await checkTopAdHasLoaded(page);
-
-	await browser.close();
+		await checkTopAdHasLoaded(page);
+	} catch (error) {
+		logErrorMessage(error);
+	} finally {
+		if (browser !== null) {
+			await browser.close();
+		}
+	}
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -132,28 +132,35 @@ const loadPage = async (page, url) => {
 const checkPage = async (url) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
-	const browser = await makeNewBrowser();
-	const page = await browser.newPage();
+	let browser = null;
+	try {
+		const browser = await makeNewBrowser();
+		const page = await browser.newPage();
 
-	// Clear cookies before starting testing, to ensure the CMP is displayed.
-	const client = await page.target().createCDPSession();
-	await clearCookies(client);
+		// Clear cookies before starting testing, to ensure the CMP is displayed.
+		const client = await page.target().createCDPSession();
+		await clearCookies(client);
 
-	await loadPage(page, url);
+		await loadPage(page, url);
 
-	await checkTopAdHasLoaded(page);
+		await checkTopAdHasLoaded(page);
 
-	await checkCMPIsOnPage(page);
+		await checkCMPIsOnPage(page);
 
-	await interactWithCMP(page);
+		await interactWithCMP(page);
 
-	await checkCMPIsNotVisible(page);
+		await checkCMPIsNotVisible(page);
 
-	await reloadPage(page);
+		await reloadPage(page);
 
-	await checkTopAdHasLoaded(page);
-
-	await browser.close();
+		await checkTopAdHasLoaded(page);
+	} catch (error) {
+		logErrorMessage(error);
+	} finally {
+		if (browser !== null) {
+			await browser.close();
+		}
+	}
 };
 
 const pageLoadBlueprint = async function () {


### PR DESCRIPTION
## What does this change?

Use the try/catch/finally block to ensure that `browser.close()` is called in the Australia and US regions, to bring the lambda functions in line with the the lambda functions in the TCF regions (Ireland and Canada).

This should alleviate our problems with this particular error in the Australia region this morning:
![image](https://user-images.githubusercontent.com/9574885/175527245-d862b80c-1f69-4978-a092-d1ca62935197.png)
