### PR TITLE
BUG: Fix catch issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ From here, you can see all the details relating to the canary and the recent run
 
 ## Development
 
-Canaries are located in the src folder. Create a new branch, make your changes to the code, then push your branch. A test canary is called `comm_cmp_canary_code` will be updated with your code by a Github Action and Riffraff. To check the progress of the update in Riffraff, go to History and search for the project `frontend::commercial-canaries`. The canary will be created in a stopped state, so you will need to click Actions -> Start to start a run.
+Canaries are located in the src folder. Create a new branch, make your changes to the code, then push your branch. A test canary `comm_cmp_canary_code` will be updated/created with your code by a Github Action and Riffraff. Check on the progress of the Github Action (here)[https://github.com/guardian/aws-canaries/actions/workflows/deploy.yaml]. If a run does not start automatically, then you can start in manually, as the workflow has a workflow_dispatch event trigger.
+
+To check the progress of the update in Riffraff, go to the History tab and search for the project `frontend::commercial-canaries`.
 
 Alternatively, you can locate the test canary in the AWS console, edit the canary, paste your code over the existing code and save.
 

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -73,7 +73,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -317,7 +317,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -561,7 +561,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -805,7 +805,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -1049,7 +1049,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -1293,7 +1293,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -1537,7 +1537,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },
@@ -1781,7 +1781,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "5",
+            "Value": "6",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -41,6 +41,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -284,6 +285,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -527,6 +529,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -770,6 +773,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1013,6 +1017,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1256,6 +1261,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1499,6 +1505,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1742,6 +1749,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
+          "MemoryInMB": 2048,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -41,7 +41,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
-          "MemoryInMB": 2048,
+          "MemoryInMB": 3008,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -285,7 +285,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
-          "MemoryInMB": 2048,
+          "MemoryInMB": 3008,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1505,7 +1505,7 @@ Object {
         },
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
-          "MemoryInMB": 2048,
+          "MemoryInMB": 3008,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
@@ -1749,7 +1749,7 @@ Object {
         },
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
-          "MemoryInMB": 2048,
+          "MemoryInMB": 3008,
           "TimeoutInSeconds": 120,
         },
         "RuntimeVersion": "syn-nodejs-puppeteer-3.6",

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -72,7 +72,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -315,7 +315,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -558,7 +558,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -801,7 +801,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -1044,7 +1044,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -1287,7 +1287,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -1530,7 +1530,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },
@@ -1773,7 +1773,7 @@ Object {
           },
           Object {
             "Key": "version",
-            "Value": "4",
+            "Value": "5",
           },
         ],
       },

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -119,7 +119,7 @@ export class CommercialCanaries extends GuStack {
 				},
 				{
 					key: 'version',
-					value: '5',
+					value: '6',
 				},
 			],
 		});

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -105,6 +105,7 @@ export class CommercialCanaries extends GuStack {
 			runtimeVersion: 'syn-nodejs-puppeteer-3.6',
 			runConfig: {
 				timeoutInSeconds: 120,
+				memoryInMb: 2048,
 			},
 			schedule: {
 				expression: 'rate(2 minutes)',

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -118,7 +118,7 @@ export class CommercialCanaries extends GuStack {
 				},
 				{
 					key: 'version',
-					value: '4',
+					value: '5',
 				},
 			],
 		});

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -32,6 +32,7 @@ export class CommercialCanaries extends GuStack {
 		const accountId = this.account;
 		const S3BucketCanary = `cw-syn-canary-${accountId}-${awsRegion}`;
 		const S3BucketResults = `cw-syn-results-${accountId}-${awsRegion}`;
+		const isTcf = awsRegion === 'eu-west-1' || awsRegion === 'ca-central-1';
 
 		// Limitation of max 21 characaters and lower case. Pattern: ^[0-9a-z_\-]+$
 		const canaryName = `comm_cmp_canary_${stage.toLocaleLowerCase()}`;
@@ -105,7 +106,7 @@ export class CommercialCanaries extends GuStack {
 			runtimeVersion: 'syn-nodejs-puppeteer-3.6',
 			runConfig: {
 				timeoutInSeconds: 120,
-				memoryInMb: 2048,
+				memoryInMb: isTcf ? 2048 : 3008,
 			},
 			schedule: {
 				expression: 'rate(2 minutes)',

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -43,6 +43,11 @@ const clearCookies = async (client) => {
 	logInfoMessage(`Cleared Cookies`);
 };
 
+const clearLocalStorage = async (page) => {
+	await page.evaluate(() => localStorage.clear());
+	logInfoMessage(`Cleared local storage`);
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	logInfoMessage(`Waiting for ads to load: Start`);
 	await page.waitForSelector(
@@ -138,7 +143,10 @@ const checkPage = async (browser, url) => {
 	const client = await page.target().createCDPSession();
 	await clearCookies(client);
 
+	// We can't clear local storage before the page is loaded
 	await loadPage(page, url);
+	await clearLocalStorage(page);
+	await reloadPage(page);
 
 	await checkTopAdHasLoaded(page);
 
@@ -151,6 +159,8 @@ const checkPage = async (browser, url) => {
 	await reloadPage(page);
 
 	await checkTopAdHasLoaded(page);
+
+	await page.close();
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -129,39 +129,28 @@ const loadPage = async (page, url) => {
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
  */
-const checkPage = async (url) => {
+const checkPage = async (browser, url) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
-	let browser = null;
-	try {
-		const browser = await makeNewBrowser();
-		const page = await browser.newPage();
+	const page = await browser.newPage();
 
-		// Clear cookies before starting testing, to ensure the CMP is displayed.
-		const client = await page.target().createCDPSession();
-		await clearCookies(client);
+	// Clear cookies before starting testing, to ensure the CMP is displayed.
+	const client = await page.target().createCDPSession();
+	await clearCookies(client);
 
-		await loadPage(page, url);
+	await loadPage(page, url);
 
-		await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page);
 
-		await checkCMPIsOnPage(page);
+	await checkCMPIsOnPage(page);
 
-		await interactWithCMP(page);
+	await interactWithCMP(page);
 
-		await checkCMPIsNotVisible(page);
+	await checkCMPIsNotVisible(page);
 
-		await reloadPage(page);
+	await reloadPage(page);
 
-		await checkTopAdHasLoaded(page);
-	} catch (error) {
-		logErrorMessage(`The canary failed for the following reason: ${error}`);
-		throw error;
-	} finally {
-		if (browser !== null) {
-			await browser.close();
-		}
-	}
+	await checkTopAdHasLoaded(page);
 };
 
 const pageLoadBlueprint = async function () {
@@ -177,17 +166,34 @@ const pageLoadBlueprint = async function () {
 		logResponse: LOG_EVERY_RESPONSE,
 	});
 
-	/**
-	 * Check front as first navigation. Then, check that ads load when viewing an article.
-	 */
-	await checkPage('https://www.theguardian.com/au?adtest=fixed-puppies');
+	let browser = null;
+	try {
+		browser = await makeNewBrowser();
 
-	/**
-	 * Check Article as first navigation.
-	 */
-	await checkPage(
-		'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
-	);
+		/**
+		 * Check front as first navigation. Then, check that ads load when viewing an article.
+		 * Note: The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com/au?adtest=fixed-puppies',
+		);
+
+		/**
+		 * Check Article as first navigation.
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
+		);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
+	} finally {
+		if (browser !== null) {
+			await browser.close();
+		}
+	}
 };
 
 exports.handler = async () => {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -154,6 +154,9 @@ const checkPage = async (url) => {
 		await reloadPage(page);
 
 		await checkTopAdHasLoaded(page);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
 	} finally {
 		if (browser !== null) {
 			await browser.close();

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -154,8 +154,6 @@ const checkPage = async (url) => {
 		await reloadPage(page);
 
 		await checkTopAdHasLoaded(page);
-	} catch (error) {
-		logErrorMessage(error);
 	} finally {
 		if (browser !== null) {
 			await browser.close();

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -129,39 +129,28 @@ const loadPage = async (page, url) => {
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
  */
-const checkPage = async (url) => {
+const checkPage = async (url, browser) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
-	let browser = null;
-	try {
-		const browser = await makeNewBrowser();
-		const page = await browser.newPage();
+	const page = await browser.newPage();
 
-		// Clear cookies before starting testing, to ensure the CMP is displayed.
-		const client = await page.target().createCDPSession();
-		await clearCookies(client);
+	// Clear cookies before starting testing, to ensure the CMP is displayed.
+	const client = await page.target().createCDPSession();
+	await clearCookies(client);
 
-		await loadPage(page, url);
+	await loadPage(page, url);
 
-		await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page);
 
-		await checkCMPIsOnPage(page);
+	await checkCMPIsOnPage(page);
 
-		await interactWithCMP(page);
+	await interactWithCMP(page);
 
-		await checkCMPIsNotVisible(page);
+	await checkCMPIsNotVisible(page);
 
-		await reloadPage(page);
+	await reloadPage(page);
 
-		await checkTopAdHasLoaded(page);
-	} catch (error) {
-		logErrorMessage(`The canary failed for the following reason: ${error}`);
-		throw error;
-	} finally {
-		if (browser !== null) {
-			await browser.close();
-		}
-	}
+	await checkTopAdHasLoaded(page);
 };
 
 const pageLoadBlueprint = async function () {
@@ -177,18 +166,34 @@ const pageLoadBlueprint = async function () {
 		logResponse: LOG_EVERY_RESPONSE,
 	});
 
-	/**
-	 * Check front as first navigation. Then, check that ads load when viewing an article.
-	 * Note: The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
-	 */
-	await checkPage('https://www.theguardian.com/us?adtest=fixed-puppies');
+	let browser = null;
+	try {
+		browser = await makeNewBrowser();
 
-	/**
-	 * Check Article as first navigation.
-	 */
-	await checkPage(
-		'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
-	);
+		/**
+		 * Check front as first navigation. Then, check that ads load when viewing an article.
+		 * Note: The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com/us?adtest=fixed-puppies',
+		);
+
+		/**
+		 * Check Article as first navigation.
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
+		);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
+	} finally {
+		if (browser !== null) {
+			await browser.close();
+		}
+	}
 };
 
 exports.handler = async () => {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -154,6 +154,9 @@ const checkPage = async (url) => {
 		await reloadPage(page);
 
 		await checkTopAdHasLoaded(page);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
 	} finally {
 		if (browser !== null) {
 			await browser.close();

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -154,8 +154,6 @@ const checkPage = async (url) => {
 		await reloadPage(page);
 
 		await checkTopAdHasLoaded(page);
-	} catch (error) {
-		logErrorMessage(error);
 	} finally {
 		if (browser !== null) {
 			await browser.close();

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -43,6 +43,11 @@ const clearCookies = async (client) => {
 	logInfoMessage(`Cleared Cookies`);
 };
 
+const clearLocalStorage = async (page) => {
+	await page.evaluate(() => localStorage.clear());
+	logInfoMessage(`Cleared local storage`);
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	logInfoMessage(`Waiting for ads to load: Start`);
 	await page.waitForSelector(
@@ -129,7 +134,7 @@ const loadPage = async (page, url) => {
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
  */
-const checkPage = async (url, browser) => {
+const checkPage = async (browser, url) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
 	const page = await browser.newPage();
@@ -138,7 +143,10 @@ const checkPage = async (url, browser) => {
 	const client = await page.target().createCDPSession();
 	await clearCookies(client);
 
+	// We can't clear local storage before the page is loaded
 	await loadPage(page, url);
+	await clearLocalStorage(page);
+	await reloadPage(page);
 
 	await checkTopAdHasLoaded(page);
 
@@ -151,6 +159,8 @@ const checkPage = async (url, browser) => {
 	await reloadPage(page);
 
 	await checkTopAdHasLoaded(page);
+
+	await page.close();
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -159,46 +159,35 @@ const loadPage = async (page, url) => {
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
  */
-const checkPage = async (url) => {
+const checkPage = async (browser, url) => {
 	logInfoMessage(`Start checking Page URL: ${url}`);
 
-	let browser = null;
-	try {
-		browser = await makeNewBrowser();
-		const page = await browser.newPage();
+	const page = await browser.newPage();
 
-		// Clear cookies & local storage before starting testing, to ensure the CMP is displayed.
-		const client = await page.target().createCDPSession();
-		await clearCookies(client);
+	// Clear cookies & local storage before starting testing, to ensure the CMP is displayed.
+	const client = await page.target().createCDPSession();
+	await clearCookies(client);
 
-		// We can't clear local storage before the page is loaded
-		await loadPage(page, url);
-		await clearLocalStorage(page);
-		await reloadPage(page);
+	// We can't clear local storage before the page is loaded
+	await loadPage(page, url);
+	await clearLocalStorage(page);
+	await reloadPage(page);
 
-		await checkCMPIsOnPage(page);
+	await checkCMPIsOnPage(page);
 
-		await checkTopAdDidNotLoad(page);
+	await checkTopAdDidNotLoad(page);
 
-		await interactWithCMP(page);
+	await interactWithCMP(page);
 
-		await checkCMPIsNotVisible(page);
+	await checkCMPIsNotVisible(page);
 
-		await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page);
 
-		await reloadPage(page);
+	await reloadPage(page);
 
-		await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page);
 
-		await checkCMPDidNotLoad(page);
-	} catch (error) {
-		logErrorMessage(`The canary failed for the following reason: ${error}`);
-		throw error;
-	} finally {
-		if (browser !== null) {
-			await browser.close();
-		}
-	}
+	await checkCMPDidNotLoad(page);
 };
 
 const pageLoadBlueprint = async function () {
@@ -214,18 +203,34 @@ const pageLoadBlueprint = async function () {
 		logResponse: LOG_EVERY_RESPONSE,
 	});
 
-	/**
-	 * Check front as first navigation. Then, check that ads load when viewing an article.
-	 * Note: The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
-	 */
-	await checkPage('https://www.theguardian.com?adtest=fixed-puppies');
+	let browser = null;
+	try {
+		browser = await makeNewBrowser();
 
-	/**
-	 * Check Article as first navigation.
-	 */
-	await checkPage(
-		'https://www.theguardian.com/environment/2022/apr/22/disbanding-of-dorset-wildlife-team-puts-birds-pray-at-risk?adtest=fixed-puppies',
-	);
+		/**
+		 * Check front as first navigation. Then, check that ads load when viewing an article.
+		 * Note: The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com?adtest=fixed-puppies',
+		);
+
+		/**
+		 * Check Article as first navigation.
+		 */
+		await checkPage(
+			browser,
+			'https://www.theguardian.com/environment/2022/apr/22/disbanding-of-dorset-wildlife-team-puts-birds-pray-at-risk?adtest=fixed-puppies',
+		);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
+	} finally {
+		if (browser !== null) {
+			await browser.close();
+		}
+	}
 };
 
 exports.handler = async () => {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -35,14 +35,14 @@ const makeNewBrowser = async () => {
 	return browser;
 };
 
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	logInfoMessage(`Cleared local storage`);
-};
-
 const clearCookies = async (client) => {
 	await client.send('Network.clearBrowserCookies');
 	logInfoMessage(`Cleared Cookies`);
+};
+
+const clearLocalStorage = async (page) => {
+	await page.evaluate(() => localStorage.clear());
+	logInfoMessage(`Cleared local storage`);
 };
 
 const checkTopAdHasLoaded = async (page) => {
@@ -188,6 +188,8 @@ const checkPage = async (browser, url) => {
 	await checkTopAdHasLoaded(page);
 
 	await checkCMPDidNotLoad(page);
+
+	await page.close();
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -191,8 +191,6 @@ const checkPage = async (url) => {
 		await checkTopAdHasLoaded(page);
 
 		await checkCMPDidNotLoad(page);
-	} catch (error) {
-		logErrorMessage(error);
 	} finally {
 		if (browser !== null) {
 			await browser.close();

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -191,6 +191,9 @@ const checkPage = async (url) => {
 		await checkTopAdHasLoaded(page);
 
 		await checkCMPDidNotLoad(page);
+	} catch (error) {
+		logErrorMessage(`The canary failed for the following reason: ${error}`);
+		throw error;
 	} finally {
 		if (browser !== null) {
 			await browser.close();


### PR DESCRIPTION
## What does this change?

The previous commit silenced errors thrown by the run with the `catch` clause. We do not want this catch clause, because when an action fails (e.g. checking for ads), we want the run to fail. We still want the finally clause, since we want the browser to be closed after every run

## Why

So that canary runs fail when an error is thrown
