### PR TITLE
Specify region prop for canary success metric

### DIFF
--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -158,6 +158,7 @@ export class CommercialCanaries extends GuStack {
 					dimensionsMap: {
 						CanaryName: canaryName,
 					},
+					region: this.region,
 				}),
 				threshold: 80,
 				treatMissingData: TreatMissingData.BREACHING,


### PR DESCRIPTION
## What does this change?

Adds `region` prop in Metric definition for "SuccessPercent" within the Alarm