### PR TITLE
Fill `SuccessPercent` metric with zeros to trigger alarm for missing data

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,53 +13,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "EvaluationPeriods": 5,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(successPercent, 0)",
-            "Id": "expr_1",
-          },
-          Object {
-            "Id": "successPercent",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "CanaryName",
-                    "Value": "comm_cmp_canary_code",
-                  },
-                ],
-                "MetricName": "SuccessPercent",
-                "Namespace": "CloudWatchSynthetics",
-              },
-              "Period": 60,
-              "Stat": "Average",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -332,11 +285,12 @@ Object {
         "EvaluationPeriods": 5,
         "Metrics": Array [
           Object {
-            "Expression": "FILL(successPercent, 0)",
+            "Expression": "FILL(successPercentRaw, 0)",
             "Id": "expr_1",
+            "Label": "successPercent",
           },
           Object {
-            "Id": "successPercent",
+            "Id": "successPercentRaw",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -621,53 +575,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "EvaluationPeriods": 5,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(successPercent, 0)",
-            "Id": "expr_1",
-          },
-          Object {
-            "Id": "successPercent",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "CanaryName",
-                    "Value": "comm_cmp_canary_code",
-                  },
-                ],
-                "MetricName": "SuccessPercent",
-                "Namespace": "CloudWatchSynthetics",
-              },
-              "Period": 60,
-              "Stat": "Average",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -940,11 +847,12 @@ Object {
         "EvaluationPeriods": 5,
         "Metrics": Array [
           Object {
-            "Expression": "FILL(successPercent, 0)",
+            "Expression": "FILL(successPercentRaw, 0)",
             "Id": "expr_1",
+            "Label": "successPercent",
           },
           Object {
-            "Id": "successPercent",
+            "Id": "successPercentRaw",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1229,53 +1137,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "EvaluationPeriods": 5,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(successPercent, 0)",
-            "Id": "expr_1",
-          },
-          Object {
-            "Id": "successPercent",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "CanaryName",
-                    "Value": "comm_cmp_canary_code",
-                  },
-                ],
-                "MetricName": "SuccessPercent",
-                "Namespace": "CloudWatchSynthetics",
-              },
-              "Period": 60,
-              "Stat": "Average",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1548,11 +1409,12 @@ Object {
         "EvaluationPeriods": 5,
         "Metrics": Array [
           Object {
-            "Expression": "FILL(successPercent, 0)",
+            "Expression": "FILL(successPercentRaw, 0)",
             "Id": "expr_1",
+            "Label": "successPercent",
           },
           Object {
-            "Id": "successPercent",
+            "Id": "successPercentRaw",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -1837,53 +1699,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "EvaluationPeriods": 5,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(successPercent, 0)",
-            "Id": "expr_1",
-          },
-          Object {
-            "Id": "successPercent",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "CanaryName",
-                    "Value": "comm_cmp_canary_code",
-                  },
-                ],
-                "MetricName": "SuccessPercent",
-                "Namespace": "CloudWatchSynthetics",
-              },
-              "Period": 60,
-              "Stat": "Average",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -2156,11 +1971,12 @@ Object {
         "EvaluationPeriods": 5,
         "Metrics": Array [
           Object {
-            "Expression": "FILL(successPercent, 0)",
+            "Expression": "FILL(successPercentRaw, 0)",
             "Id": "expr_1",
+            "Label": "successPercent",
           },
           Object {
-            "Id": "successPercent",
+            "Id": "successPercentRaw",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -148,36 +148,36 @@ export class CommercialCanaries extends GuStack {
 		});
 
 		// We add the alarm only for PROD but it's easier to keep the topic and subscription in both stages.
-		// if (stage === 'PROD') {
-		const alarm = new Alarm(this, 'Alarm', {
-			actionsEnabled: true,
-			alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
-			alarmName: `commercial-canary-${stage}`,
-			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-			datapointsToAlarm: 5,
-			evaluationPeriods: 5,
-			metric: new MathExpression({
-				// Make sure to fill in missing data with 0 before calculating the average
-				expression: 'FILL(successPercent, 0)',
-				period: Duration.minutes(1),
-				usingMetrics: {
-					successPercent: new Metric({
-						namespace: 'CloudWatchSynthetics',
-						metricName: 'SuccessPercent',
-						statistic: 'avg',
-						period: Duration.minutes(1),
-						dimensionsMap: {
-							CanaryName: canaryName,
-						},
-					}),
-				},
-			}),
-			threshold: 80,
-			treatMissingData: TreatMissingData.BREACHING,
-		});
+		if (stage === 'PROD') {
+			const alarm = new Alarm(this, 'Alarm', {
+				actionsEnabled: true,
+				alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
+				alarmName: `commercial-canary-${stage}`,
+				comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+				datapointsToAlarm: 5,
+				evaluationPeriods: 5,
+				metric: new MathExpression({
+					label: 'successPercent',
+					expression: 'FILL(successPercentRaw, 0)',
+					period: Duration.minutes(1),
+					usingMetrics: {
+						successPercentRaw: new Metric({
+							namespace: 'CloudWatchSynthetics',
+							metricName: 'SuccessPercent',
+							statistic: 'avg',
+							period: Duration.minutes(1),
+							dimensionsMap: {
+								CanaryName: canaryName,
+							},
+						}),
+					},
+				}),
+				threshold: 80,
+				treatMissingData: TreatMissingData.BREACHING,
+			});
 
-		alarm.addAlarmAction(new SnsAction(topic));
-		alarm.addOkAction(new SnsAction(topic));
+			alarm.addAlarmAction(new SnsAction(topic));
+			alarm.addOkAction(new SnsAction(topic));
+		}
 	}
 }
-// }


### PR DESCRIPTION
## What does this change?

Adds a [math expression](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.MathExpression.html) to the original alarm metric to ensure that the alarm is triggered for missing data:

- `FILL(successPercentRaw, 0)` fills in the `SuccessPercent` metric with `0` for missing data

This means that if the canary is stopped for any reason, we should be notified
