### PR TITLE
Fix content directories configuration for RiffRaff

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
-            upload-uk:
+            upload-eu:
               - builds/tcfv2
             upload-ca:
               - builds/tcfv2


### PR DESCRIPTION
## What does this change?

Fixes a mistake in the PR https://github.com/guardian/commercial-canaries/pull/72 where `contentDirectories` in the RiffRaff Github action was not updated to reflect the new infrastructure naming