### PR TITLE
Use `fixed-puppies-ci` in canary steps for all regions

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -327,18 +327,18 @@ const pageLoadBlueprint = async function () {
 
 	startTime = new Date().getTime();
 
-	// The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {
 		await checkPage(
 			'front',
-			'https://www.theguardian.com/au?adtest=fixed-puppies',
+			'https://www.theguardian.com/au?adtest=fixed-puppies-ci',
 		);
 	});
 
 	await synthetics.executeStep('Test Article page', async function () {
 		await checkPage(
 			'article',
-			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
+			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies-ci',
 		);
 	});
 };

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -340,18 +340,18 @@ const pageLoadBlueprint = async function () {
 
 	startTime = new Date().getTime();
 
-	// The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {
 		await checkPage(
 			'front',
-			'https://www.theguardian.com/us?adtest=fixed-puppies',
+			'https://www.theguardian.com/us?adtest=fixed-puppies-ci',
 		);
 	});
 
 	await synthetics.executeStep('Test Article page', async function () {
 		await checkPage(
 			'article',
-			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies',
+			'https://www.theguardian.com/food/2020/dec/16/how-to-make-the-perfect-vegetarian-sausage-rolls-recipe-felicity-cloake?adtest=fixed-puppies-ci',
 		);
 	});
 };

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -375,18 +375,18 @@ const pageLoadBlueprint = async function () {
 
 	startTime = new Date().getTime();
 
-	// The query param "adtest=fixed-puppies" is used to ensure that GAM provides us with an ad for our slot
+	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {
 		await checkPage(
 			'front',
-			'https://www.theguardian.com?adtest=fixed-puppies',
+			'https://www.theguardian.com?adtest=fixed-puppies-ci',
 		);
 	});
 
 	await synthetics.executeStep('Test Article page', async function () {
 		await checkPage(
 			'article',
-			'https://www.theguardian.com/environment/2022/apr/22/disbanding-of-dorset-wildlife-team-puts-birds-pray-at-risk?adtest=fixed-puppies',
+			'https://www.theguardian.com/environment/2022/apr/22/disbanding-of-dorset-wildlife-team-puts-birds-pray-at-risk?adtest=fixed-puppies-ci',
 		);
 	});
 };


### PR DESCRIPTION
## What does this change?

Replaces `fixed-puppies` with `fixed-puppies-ci` in the canary steps for all regions

## Why

We noticed the Canary steps failing a lot in Australia which was down to this ad test parameter negatively targeting this region in GAM

## How to test

Deploy to CODE in AWS via RiffRaff