### PR TITLE
Add folder for shared functions and standardise timeout values

### DIFF
--- a/.github/scripts/create-artifacts.sh
+++ b/.github/scripts/create-artifacts.sh
@@ -8,6 +8,7 @@ echo "Creating TCFV2 artifact..."
 mkdir -p tcfv2/nodejs/node_modules
 cd tcfv2
 cp ../../src/cmp_tcfv2.js nodejs/node_modules/pageLoadBlueprint.js
+cp -r ../../src/utils nodejs/node_modules
 zip -r nodejs.zip nodejs
 rm -rf nodejs
 cd ..
@@ -17,6 +18,7 @@ echo "Creating CCPA artifact..."
 mkdir -p ccpa/nodejs/node_modules
 cd ccpa
 cp ../../src/cmp_ccpa.js nodejs/node_modules/pageLoadBlueprint.js
+cp -r ../../src/utils nodejs/node_modules
 zip -r nodejs.zip nodejs
 rm -rf nodejs
 cd ..
@@ -26,6 +28,7 @@ echo "Creating AUS artifact..."
 mkdir -p aus/nodejs/node_modules
 cd aus
 cp ../../src/cmp_aus.js nodejs/node_modules/pageLoadBlueprint.js
+cp -r ../../src/utils nodejs/node_modules
 zip -r nodejs.zip nodejs
 rm -rf nodejs
 cd ..

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,44 +1,27 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const {
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+	interactWithCMPAus,
+} = require('./utils/cmp');
+const { TWO_SECONDS, TWENTY_SECONDS } = require('./utils/constants');
+const { log, logError } = require('./utils/logging');
+const {
+	clearLocalStorage,
+	clearCookies,
+	loadPage,
+	reloadPage,
+} = require('./utils/page');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
 			'.ad-slot--top-above-nav .ad-slot__content iframe',
-			{ timeout: 2000 },
+			{ timeout: TWENTY_SECONDS },
 		);
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
@@ -48,68 +31,7 @@ const checkTopAdHasLoaded = async (page, pageType) => {
 		);
 		throw new Error('top-above-nav ad did not load');
 	}
-
 	log(`Waiting for ads to load: Complete`);
-};
-
-const interactWithCMP = async (page) => {
-	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
-	log(`Clicking on "Continue" on CMP`);
-
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
-	await frame.click('button[title="Continue"]');
-};
-
-const checkCMPIsOnPage = async (page, pageType) => {
-	log(`Waiting for CMP: Start`);
-	try {
-		await page.waitForSelector('[id*="sp_message_container"]', {
-			timeout: 2000,
-		});
-	} catch (e) {
-		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for CMP: Finish`);
-};
-
-const checkCMPIsNotVisible = async (page) => {
-	log(`Checking CMP is Hidden: Start`);
-
-	const getSpMessageDisplayProperty = function () {
-		const element = document.querySelector('[id*="sp_message_container"]');
-		if (element) {
-			const computedStyle = window.getComputedStyle(element);
-			return computedStyle.getPropertyValue('display');
-		}
-	};
-
-	const display = await page.evaluate(getSpMessageDisplayProperty);
-
-	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display && display != 'none') {
-		throw Error('CMP still present on page');
-	}
-	log('CMP hidden or removed from page');
-};
-
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-
-	log(`Reloading page: Complete`);
 };
 
 const checkPrebid = async (page) => {
@@ -119,7 +41,7 @@ const checkPrebid = async (page) => {
 	try {
 		await page.waitForRequest(
 			(req) => req.url().includes('graun.Prebid.js.commercial.js'),
-			{ timeout: 2000 },
+			{ timeout: TWO_SECONDS },
 		);
 	} catch (timeoutError) {
 		const hasPageskin = await page.evaluate(() =>
@@ -143,7 +65,7 @@ const checkPrebid = async (page) => {
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL), {
-		timeout: 2000,
+		timeout: TWO_SECONDS,
 	});
 	log(`[TEST 4: PUBMATIC] Step complete`);
 	// --------------- PUBMATIC END ---------------------------
@@ -151,8 +73,10 @@ const checkPrebid = async (page) => {
 	// --------------- PBJS START ---------------------------
 	log(`[TEST 4: PBJS] Step start`);
 	const hasPrebid = await page.waitForFunction(
-		() => window.pbjs !== undefined,
-		{ timeout: 2000 },
+		() =>
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
+			window.pbjs !== undefined,
+		{ timeout: TWO_SECONDS },
 	);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
@@ -163,9 +87,9 @@ const checkPrebid = async (page) => {
 
 	// --------------- BID RESPONSE START ---------------------------
 	log(`[TEST 4: BID RESPONSE] Step start`);
-
 	await page.waitForFunction(
 		() => {
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
 			const events = window.pbjs?.getEvents() ?? [];
 			return events.find(
 				(event) =>
@@ -173,10 +97,11 @@ const checkPrebid = async (page) => {
 					event.args.adUnitCodes.includes('dfp-ad--top-above-nav'),
 			);
 		},
-		{ timeout: 2000 },
+		{ timeout: TWO_SECONDS },
 	);
 
 	const topAboveNavBidderRequests = await page.evaluate(() => {
+		// eslint-disable-next-line no-undef -- window object exists in the browser only
 		const auctionInitEvent = window.pbjs
 			?.getEvents()
 			.find(
@@ -230,28 +155,8 @@ const checkPrebid = async (page) => {
 	} else {
 		log(`[TEST 4: BID RESPONSE] Not all bidders matched`);
 	}
-
 	log(`[TEST 4: BID RESPONSE] Step complete`);
 	// --------------- BID RESPONSE END ---------------------------
-};
-
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-	log(`Loading page: Complete`);
 };
 
 /**
@@ -280,9 +185,8 @@ const checkPage = async (pageType, url) => {
 	log(
 		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
-	await interactWithCMP(page);
+	await interactWithCMPAus(page);
 	await checkCMPIsNotVisible(page);
-
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
@@ -330,8 +234,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -1,45 +1,27 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const {
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+	interactWithCMPCcpa,
+} = require('./utils/cmp');
+const { TWO_SECONDS, TWENTY_SECONDS } = require('./utils/constants');
+const { log, logError } = require('./utils/logging');
+const {
+	clearLocalStorage,
+	clearCookies,
+	loadPage,
+	reloadPage,
+} = require('./utils/page');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- *
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
 			'.ad-slot--top-above-nav .ad-slot__content iframe',
-			{ timeout: 10000 },
+			{ timeout: TWENTY_SECONDS },
 		);
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
@@ -49,67 +31,7 @@ const checkTopAdHasLoaded = async (page, pageType) => {
 		);
 		throw new Error('top-above-nav ad did not load');
 	}
-
 	log(`Waiting for ads to load: Complete`);
-};
-
-const interactWithCMP = async (page) => {
-	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
-	log(`Clicking on "Do not sell or share my personal information" on CMP`);
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
-
-	if (frame) {
-		await frame.waitForSelector(
-			'button[title="Do not sell or share my personal information"]',
-			{ timeout: 2000 },
-		);
-		await frame.click(
-			'button[title="Do not sell or share my personal information"]',
-		);
-	} else {
-		logError('CMP frame not found');
-	}
-
-	await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
-};
-
-const checkCMPIsOnPage = async (page, pageType) => {
-	log(`Waiting for CMP: Start`);
-	try {
-		await page.waitForSelector('[id*="sp_message_container"]', {
-			timeout: 2000,
-		});
-	} catch (e) {
-		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for CMP: Finish`);
-};
-
-const checkCMPIsNotVisible = async (page) => {
-	log(`Checking CMP is Hidden: Start`);
-
-	const getSpMessageDisplayProperty = function () {
-		const element = document.querySelector('[id*="sp_message_container"]');
-		if (element) {
-			const computedStyle = window.getComputedStyle(element);
-			return computedStyle.getPropertyValue('display');
-		}
-	};
-
-	const display = await page.evaluate(getSpMessageDisplayProperty);
-
-	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display && display != 'none') {
-		throw Error('CMP still present on page');
-	}
-
-	log('CMP hidden or removed from page');
 };
 
 const checkPrebid = async (page) => {
@@ -119,7 +41,7 @@ const checkPrebid = async (page) => {
 	try {
 		await page.waitForRequest(
 			(req) => req.url().includes('graun.Prebid.js.commercial.js'),
-			{ timeout: 2000 },
+			{ timeout: TWO_SECONDS },
 		);
 	} catch (timeoutError) {
 		const hasPageskin = await page.evaluate(() =>
@@ -143,7 +65,7 @@ const checkPrebid = async (page) => {
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL), {
-		timeout: 2000,
+		timeout: TWO_SECONDS,
 	});
 	log(`[TEST 4: PUBMATIC] Step complete`);
 	// --------------- PUBMATIC END ---------------------------
@@ -151,8 +73,10 @@ const checkPrebid = async (page) => {
 	// --------------- PBJS START ---------------------------
 	log(`[TEST 4: PBJS] Step start`);
 	const hasPrebid = await page.waitForFunction(
-		() => window.pbjs !== undefined,
-		{ timeout: 2000 },
+		() =>
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
+			window.pbjs !== undefined,
+		{ timeout: TWO_SECONDS },
 	);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
@@ -165,6 +89,7 @@ const checkPrebid = async (page) => {
 	log(`[TEST 4: BID RESPONSE] Step start`);
 	await page.waitForFunction(
 		() => {
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
 			const events = window.pbjs?.getEvents() ?? [];
 			return events.find(
 				(event) =>
@@ -172,10 +97,11 @@ const checkPrebid = async (page) => {
 					event.args.adUnitCodes.includes('dfp-ad--top-above-nav'),
 			);
 		},
-		{ timeout: 2000 },
+		{ timeout: TWO_SECONDS },
 	);
 
 	const topAboveNavBidderRequests = await page.evaluate(() => {
+		// eslint-disable-next-line no-undef -- window object exists in the browser only
 		const auctionInitEvent = window.pbjs
 			?.getEvents()
 			.find(
@@ -236,38 +162,6 @@ const checkPrebid = async (page) => {
 	// --------------- BID RESPONSE END ---------------------------
 };
 
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-	log(`Reloading page: Complete`);
-};
-
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-	log(`Loading page: Complete`);
-};
-
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -294,12 +188,14 @@ const checkPage = async (pageType, url) => {
 	log(
 		`[Test 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
-	await interactWithCMP(page);
+	await interactWithCMPCcpa(page);
 	await checkCMPIsNotVisible(page);
+	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
 	);
+	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 2]  completed`);
 
@@ -341,8 +237,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -1,44 +1,27 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const {
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+	interactWithCMPTcfv2,
+} = require('./utils/cmp');
+const { TWO_SECONDS, TWENTY_SECONDS } = require('./utils/constants');
+const { log, logError } = require('./utils/logging');
+const {
+	clearLocalStorage,
+	clearCookies,
+	loadPage,
+	reloadPage,
+} = require('./utils/page');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
 			'.ad-slot--top-above-nav .ad-slot__content iframe',
-			{ timeout: 10000 },
+			{ timeout: TWENTY_SECONDS },
 		);
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
@@ -67,90 +50,9 @@ const checkTopAdDidNotLoad = async (page) => {
 	log(`Checking ads do not load: Complete`);
 };
 
-const interactWithCMP = async (page) => {
-	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
-	log(`Clicking on "Yes I'm Happy"`);
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
-
-	// Accept cookies
-	await frame.click(
-		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
-	);
-};
-
-const checkCMPIsOnPage = async (page, pageType) => {
-	log(`Waiting for CMP: Start`);
-	try {
-		await page.waitForSelector('[id*="sp_message_container"]', {
-			timeout: 2000,
-		});
-	} catch (e) {
-		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for CMP: Finish`);
-};
-
-const checkCMPIsNotVisible = async (page) => {
-	log(`Checking CMP is Hidden: Start`);
-
-	const getSpMessageDisplayProperty = function () {
-		const element = document.querySelector('[id*="sp_message_container"]');
-		if (element) {
-			const computedStyle = window.getComputedStyle(element);
-			return computedStyle.getPropertyValue('display');
-		}
-	};
-
-	const display = await page.evaluate(getSpMessageDisplayProperty);
-
-	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display && display != 'none') {
-		throw Error('CMP still present on page');
-	}
-
-	log('CMP hidden or removed from page');
-};
-
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-	log(`Reloading page: Complete`);
-};
-
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-	log(`Loading page: Complete`);
-};
-
 const getCurrentLocation = async (page) => {
 	const currentLocation = () => {
+		// eslint-disable-next-line no-undef -- document object exists in the browser only
 		return document.cookie
 			.split('; ')
 			.find((row) => row.startsWith('GU_geo_country='))
@@ -169,7 +71,7 @@ const checkPrebid = async (page) => {
 	try {
 		await page.waitForRequest(
 			(req) => req.url().includes('graun.Prebid.js.commercial.js'),
-			{ timeout: 2000 },
+			{ timeout: TWO_SECONDS },
 		);
 	} catch (timeoutError) {
 		if (currentLocation === 'CA') {
@@ -196,14 +98,16 @@ const checkPrebid = async (page) => {
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL), {
-		timeout: 2000,
+		timeout: TWO_SECONDS,
 	});
 	log(`[TEST 4: PUBMATIC] Step complete`);
 
 	log(`[TEST 4: PBJS] Step start`);
 	const hasPrebid = await page.waitForFunction(
-		() => window.pbjs !== undefined,
-		{ timeout: 2000 },
+		() =>
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
+			window.pbjs !== undefined,
+		{ timeout: TWO_SECONDS },
 	);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
@@ -212,9 +116,9 @@ const checkPrebid = async (page) => {
 	log(`[TEST 4: PBJS] Step complete`);
 
 	log(`[TEST 4: BID RESPONSE] Step start`);
-
 	await page.waitForFunction(
 		() => {
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
 			const events = window.pbjs?.getEvents() ?? [];
 			return events.find(
 				(event) =>
@@ -222,10 +126,11 @@ const checkPrebid = async (page) => {
 					event.args.adUnitCodes.includes('dfp-ad--top-above-nav'),
 			);
 		},
-		{ timeout: 2000 },
+		{ timeout: TWO_SECONDS },
 	);
 
 	const topAboveNavBidderRequests = await page.evaluate(() => {
+		// eslint-disable-next-line no-undef -- window object exists in the browser only
 		const auctionInitEvent = window.pbjs
 			?.getEvents()
 			.find(
@@ -314,7 +219,7 @@ const checkPage = async (pageType, url) => {
 	log(
 		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
-	await interactWithCMP(page);
+	await interactWithCMPTcfv2(page);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 2]  completed`);
@@ -369,8 +274,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/utils/cmp.js
+++ b/src/utils/cmp.js
@@ -1,0 +1,98 @@
+const { URL } = require('url');
+const synthetics = require('Synthetics');
+const { TWO_SECONDS } = require('./constants');
+const { log, logError } = require('./logging');
+
+const interactWithCMPTcfv2 = async (page) => {
+	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
+	log(`Clicking on "Yes I'm Happy"`);
+	const frame = page.frames().find((f) => {
+		const parsedUrl = new URL(f.url());
+		return parsedUrl.host === 'sourcepoint.theguardian.com';
+	});
+
+	// Accept cookies
+	await frame.click(
+		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
+	);
+};
+
+const interactWithCMPCcpa = async (page) => {
+	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
+	log(`Clicking on "Do not sell or share my personal information" on CMP`);
+	const frame = page.frames().find((f) => {
+		const parsedUrl = new URL(f.url());
+		return parsedUrl.host === 'sourcepoint.theguardian.com';
+	});
+
+	if (frame) {
+		await frame.waitForSelector(
+			'button[title="Do not sell or share my personal information"]',
+			{ timeout: TWO_SECONDS },
+		);
+		await frame.click(
+			'button[title="Do not sell or share my personal information"]',
+		);
+	} else {
+		logError('CMP frame not found');
+	}
+
+	await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
+	// We see some run failures if we do not include a wait time after a page load
+	await page.waitForTimeout(TWO_SECONDS);
+};
+
+const interactWithCMPAus = async (page) => {
+	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
+	log(`Clicking on "Continue" on CMP`);
+	const frame = page.frames().find((f) => {
+		const parsedUrl = new URL(f.url());
+		return parsedUrl.host === 'sourcepoint.theguardian.com';
+	});
+	await frame.click('button[title="Continue"]');
+};
+
+const checkCMPIsOnPage = async (page, pageType) => {
+	log(`Waiting for CMP: Start`);
+	try {
+		await page.waitForSelector('[id*="sp_message_container"]', {
+			timeout: TWO_SECONDS,
+		});
+	} catch (e) {
+		logError(`Could not find CMP: ${e.message}`);
+		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
+		throw new Error('top-above-nav ad did not load');
+	}
+	log(`Waiting for CMP: Finish`);
+};
+
+const checkCMPIsNotVisible = async (page) => {
+	log(`Checking CMP is Hidden: Start`);
+
+	const getSpMessageDisplayProperty = function () {
+		// eslint-disable-next-line no-undef -- document object exists in the browser only
+		const element = document.querySelector('[id*="sp_message_container"]');
+		if (element) {
+			// eslint-disable-next-line no-undef -- window object exists in the browser only
+			const computedStyle = window.getComputedStyle(element);
+			return computedStyle.getPropertyValue('display');
+		}
+	};
+
+	const display = await page.evaluate(getSpMessageDisplayProperty);
+
+	// Use `!=` rather than `!==` here because display is a DOMString type
+	if (display && display != 'none') {
+		throw Error('CMP still present on page');
+	}
+
+	log('CMP hidden or removed from page');
+};
+
+module.exports = {
+	interactWithCMPTcfv2,
+	interactWithCMPCcpa,
+	interactWithCMPAus,
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,14 @@
+/** Ten (10) seconds in milliseconds */
+const TEN_SECONDS = 10000;
+
+/** Two (2) seconds in milliseconds */
+const TWO_SECONDS = 2000;
+
+/** Twenty (20) seconds in milliseconds */
+const TWENTY_SECONDS = 20000;
+
+module.exports = {
+	TEN_SECONDS,
+	TWO_SECONDS,
+	TWENTY_SECONDS,
+};

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -1,0 +1,16 @@
+const logger = require('SyntheticsLogger');
+
+/**
+ * We use custom log messages so that we can easily differentiate
+ * between logs from this file and other logs in Cloudwatch.
+ */
+const formatMessage = (message) => `GuCanaryRun: ${message}`;
+
+const log = (message) => logger.info(formatMessage(message));
+
+const logError = (message) => logger.error(formatMessage(message));
+
+module.exports = {
+	log,
+	logError,
+};

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -1,0 +1,52 @@
+const { TEN_SECONDS } = require('./constants');
+const { log, logError } = require('./logging');
+
+const clearCookies = async (page) => {
+	const allCookies = await page.cookies();
+	await page.deleteCookie(...allCookies);
+	log(`Cleared Cookies`);
+};
+
+const clearLocalStorage = async (page) => {
+	// eslint-disable-next-line no-undef -- localStorage object exists in the browser only
+	await page.evaluate(() => localStorage.clear());
+	log(`Cleared local storage`);
+};
+
+const loadPage = async (page, url) => {
+	log(`Loading page: Start`);
+	const response = await page.goto(url, {
+		waitUntil: 'domcontentloaded',
+		timeout: TEN_SECONDS,
+	});
+	if (!response) {
+		logError('Loading page: Failed');
+		throw 'Failed to load page!';
+	}
+	// If the response status code is not a 2xx success code
+	if (response.status() < 200 || response.status() > 299) {
+		logError(`Loading page: Failed. Status code: ${response.status()}`);
+		throw 'Failed to load page!';
+	}
+	log(`Loading page: Complete`);
+};
+
+const reloadPage = async (page) => {
+	log(`Reloading page: Start`);
+	const reloadResponse = await page.reload({
+		waitUntil: 'domcontentloaded',
+		timeout: TEN_SECONDS,
+	});
+	if (!reloadResponse) {
+		logError(`Reloading page: Failed`);
+		throw 'Failed to refresh page!';
+	}
+	log(`Reloading page: Complete`);
+};
+
+module.exports = {
+	clearCookies,
+	clearLocalStorage,
+	loadPage,
+	reloadPage,
+};


### PR DESCRIPTION
## What are you changing?

- Adds `utils` directory to store common functionality between the various canaries
- Adds `TWO_SECONDS`, `TEN_SECONDS`, `TWENTY_SECONDS` constants to better illustrate the chosen timeout values
- Temporarily adds eslint disable comments for missing global values to allow IDEs to better highlight _real_ errors. This would be improved by using `globals` in the eslint config, but keeping changes small for PRs

## Why?

- Abstracting common functions away to avoid the files becoming too long and hard to read. The canaries largely do the same thing so can share a lot of logic between them.