### PR TITLE
Update Prebid bundle checking function and use timeout values for all `waitFor` functions

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -132,8 +132,8 @@ const checkPrebid = async (page) => {
 			return Promise.resolve();
 		}
 
-		logError('Prebid bundle not loaded');
-		throw new Error(timeoutError);
+		logError('[TEST 4: PREBID BUNDLE] Prebid bundle not loaded');
+		throw timeoutError;
 	}
 	log(`[TEST 4: PREBID BUNDLE] Step complete`);
 

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -132,8 +132,8 @@ const checkPrebid = async (page) => {
 			return Promise.resolve();
 		}
 
-		logError('Prebid bundle not loaded');
-		throw new Error(timeoutError);
+		logError('[TEST 4: PREBID BUNDLE] Prebid bundle not loaded');
+		throw timeoutError;
 	}
 	log(`[TEST 4: PREBID BUNDLE] Step complete`);
 

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -186,8 +186,8 @@ const checkPrebid = async (page) => {
 			return Promise.resolve();
 		}
 
-		logError('Prebid bundle not loaded');
-		throw new Error(timeoutError);
+		logError('[TEST 4: PREBID BUNDLE] Prebid bundle not loaded');
+		throw timeoutError;
 	}
 	log(`[TEST 4: PREBID BUNDLE] Step complete`);
 


### PR DESCRIPTION
## What are you changing?

- Updates the function to check for the request to the Prebid bundle in a try catch block:
  - Checks for the request first for all regions
  - If request not identified after the timeout, then check if there is a page skin (and additionally if we are in Canada for TCFV2) where we exit the prebid checking step entirely by returning `Promise.resolve`
- Updates timeout values for `waitFor` functions:
  - Previously defined 30 second timeouts become 10 seconds (top above nav loading)
  - Previously undefined timeouts become 2 seconds
  - Unnecessary timeouts have been removed (`loadPage`, `reloadPage`)

## Why?

- The Canary is failing very often in the Canada region. This is party due to time spent waiting for timeouts and also due to the Prebid checking function failing. We don't run Prebid in Canada so we need to exit this step as soon as possible to avoid wasting the Canary running time available
- The timeout values are so long that the lambda is shut down before the canary has finished execution
  - The overall timeout of the canary is 60 seconds:
    https://github.com/guardian/commercial-canaries/blob/79a271484c2dbed9077aedac3b117857ef8719f3/cdk/lib/commercial-canaries.ts#L57 
  so we should keep each individual timeout as low as possible
  - Where timeouts were not explicitly specified, they were defaulting to `30000` (30 seconds). Given that 30 seconds is the maximum length of time we would expect _one_ of our canary steps to take, we are causing the second step (article) to fail to run as our first step (front) is taking up all of the time available to the canary
    - A future improvement here is to separate the front and article steps into separate canaries so that they do not influence each other 
