### PR TITLE
Fix screenshot name

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -33,7 +33,7 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
-const checkTopAdHasLoaded = async (page) => {
+const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
@@ -43,7 +43,7 @@ const checkTopAdHasLoaded = async (page) => {
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
 		await synthetics.takeScreenshot(
-			`${page}-page`,
+			`${pageType}-page`,
 			'Failed to load top-above-nav ad',
 		);
 		throw new Error('top-above-nav ad did not load');
@@ -63,13 +63,13 @@ const interactWithCMP = async (page) => {
 	await frame.click('button[title="Continue"]');
 };
 
-const checkCMPIsOnPage = async (page) => {
+const checkCMPIsOnPage = async (page, pageType) => {
 	log(`Waiting for CMP: Start`);
 	try {
 		await page.waitForSelector('[id*="sp_message_container"]');
 	} catch (e) {
 		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
+		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
 		throw new Error('top-above-nav ad did not load');
 	}
 
@@ -284,8 +284,8 @@ const checkPage = async (pageType, url) => {
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
-	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
+	await checkCMPIsOnPage(page, pageType);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 1] completed`);
 
 	log(
@@ -300,7 +300,7 @@ const checkPage = async (pageType, url) => {
 		'CMP clicked then page reloaded',
 	);
 	await checkCMPIsNotVisible(page);
-	await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 2]  completed`);
 
 	log(
@@ -313,8 +313,8 @@ const checkPage = async (pageType, url) => {
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
+	await checkCMPIsOnPage(page, pageType);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 3] completed`);
 
 	log(`[TEST 4] start: Prebid`);

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -34,7 +34,7 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
-const checkTopAdHasLoaded = async (page) => {
+const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
@@ -44,7 +44,7 @@ const checkTopAdHasLoaded = async (page) => {
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
 		await synthetics.takeScreenshot(
-			`${page}-page`,
+			`${pageType}-page`,
 			'Failed to load top-above-nav ad',
 		);
 		throw new Error('top-above-nav ad did not load');
@@ -78,13 +78,13 @@ const interactWithCMP = async (page) => {
 	await page.waitForTimeout(3000);
 };
 
-const checkCMPIsOnPage = async (page) => {
+const checkCMPIsOnPage = async (page, pageType) => {
 	log(`Waiting for CMP: Start`);
 	try {
 		await page.waitForSelector('[id*="sp_message_container"]');
 	} catch (e) {
 		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
+		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
 		throw new Error('top-above-nav ad did not load');
 	}
 
@@ -300,8 +300,8 @@ const checkPage = async (pageType, url) => {
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
-	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
+	await checkCMPIsOnPage(page, pageType);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 1] completed`);
 
 	log(
@@ -313,7 +313,7 @@ const checkPage = async (pageType, url) => {
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
 	);
-	await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 2]  completed`);
 
 	log(
@@ -326,8 +326,8 @@ const checkPage = async (pageType, url) => {
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
+	await checkCMPIsOnPage(page, pageType);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 3] completed`);
 
 	log(`[TEST 4] start: Prebid`);

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -33,7 +33,7 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
-const checkTopAdHasLoaded = async (page) => {
+const checkTopAdHasLoaded = async (page, pageType) => {
 	log(`Waiting for ads to load: Start`);
 	try {
 		await page.waitForSelector(
@@ -43,7 +43,7 @@ const checkTopAdHasLoaded = async (page) => {
 	} catch (e) {
 		logError(`Failed to load top-above-nav ad: ${e.message}`);
 		await synthetics.takeScreenshot(
-			`${page}-page`,
+			`${pageType}-page`,
 			'Failed to load top-above-nav ad',
 		);
 		throw new Error('top-above-nav ad did not load');
@@ -81,13 +81,13 @@ const interactWithCMP = async (page) => {
 	);
 };
 
-const checkCMPIsOnPage = async (page) => {
+const checkCMPIsOnPage = async (page, pageType) => {
 	log(`Waiting for CMP: Start`);
 	try {
 		await page.waitForSelector('[id*="sp_message_container"]');
 	} catch (e) {
 		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
+		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
 		throw new Error('top-above-nav ad did not load');
 	}
 
@@ -327,7 +327,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
-	await checkCMPIsOnPage(page);
+	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdDidNotLoad(page);
 	log(`[TEST 1] completed`);
 
@@ -336,7 +336,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
-	await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 2]  completed`);
 
 	log(
@@ -348,7 +348,7 @@ const checkPage = async (pageType, url) => {
 		'CMP clicked then page reloaded',
 	);
 	await checkCMPIsNotVisible(page);
-	await checkTopAdHasLoaded(page);
+	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 3] completed`);
 
 	log(`[TEST 4] start: Prebid`);
@@ -365,7 +365,7 @@ const checkPage = async (pageType, url) => {
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page);
+	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdDidNotLoad(page);
 	log(`[TEST 5] completed`);
 };


### PR DESCRIPTION
## What are you changing?

- Adds `pageType` argument to functions requiring this context for the name of the screenshot

## Why?

- Screenshot of step appears as 
  `Custom Screenshot: 05-[object Object]-page-Could not find CMP` 
  instead of 
  `Custom Screenshot: 05-Article-page-Could not find CMP`

  _See screenshot_
  <img width="869" alt="image" src="https://github.com/user-attachments/assets/4024a8d7-3878-48c6-84d3-c6051aaddfa0" />

