### PR TITLE
Wait two seconds extra after reloading the page and before taking screenshots

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -189,6 +189,7 @@ const checkPage = async (pageType, url) => {
 	await interactWithCMPAus(page);
 	await checkCMPIsNotVisible(page);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
@@ -203,6 +204,7 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -180,6 +180,7 @@ const checkPage = async (pageType, url) => {
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdHasLoaded(page, pageType);
@@ -191,6 +192,7 @@ const checkPage = async (pageType, url) => {
 	await interactWithCMPCcpa(page);
 	await checkCMPIsNotVisible(page);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
@@ -205,6 +207,7 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -211,6 +211,7 @@ const checkPage = async (pageType, url) => {
 		`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`,
 	);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdDidNotLoad(page);
@@ -228,6 +229,7 @@ const checkPage = async (pageType, url) => {
 		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
 	);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
@@ -246,6 +248,7 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
+	await page.waitForTimeout(TWO_SECONDS); // Wait an extra two seconds after reloading the page
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',


### PR DESCRIPTION
## What are you changing?

- As described in title, waits two seconds after reloading the page before taking screenshots

## Why?

- The ads have not fully loaded by the time the screenshot is taken which makes the errors harder to debug in the AWS console
