### PR TITLE
Fix error message for CMP not loading

### DIFF
--- a/src/utils/cmp.js
+++ b/src/utils/cmp.js
@@ -61,7 +61,7 @@ const checkCMPIsOnPage = async (page, pageType) => {
 	} catch (e) {
 		logError(`Could not find CMP: ${e.message}`);
 		await synthetics.takeScreenshot(`${pageType}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
+		throw new Error(e);
 	}
 	log(`Waiting for CMP: Finish`);
 };


### PR DESCRIPTION
## What are you changing?

Fixes a copy and paste bug where the wrong error message is being thrown when the CMP isn't 
found on the page

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/cf9ae7ca-1f04-4eea-8290-d9a8c4a29430
[after]:https://github.com/user-attachments/assets/1cf61190-5bd2-4b2e-9b6c-2a7ec5e1ab64