### PR TITLE
Increase CMP detection timeouts, takes screenshots after checking CMP

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -39,9 +39,8 @@ const checkPage = async (pageType, url) => {
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
-	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page, pageType);
+	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 1] completed`);
 
@@ -66,12 +65,11 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
+	await checkCMPIsOnPage(page, pageType);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 3] completed`);
 

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -39,9 +39,8 @@ const checkPage = async (pageType, url) => {
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
-	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page, pageType);
+	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 1] completed`);
 
@@ -66,12 +65,11 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
+	await checkCMPIsOnPage(page, pageType);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdHasLoaded(page, pageType);
 	log(`[TEST 3] completed`);
 

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -43,9 +43,8 @@ const checkPage = async (pageType, url) => {
 		`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`,
 	);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
-	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page, pageType);
+	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkTopAdDidNotLoad(page);
 	log(`[TEST 1] completed`);
 
@@ -101,12 +100,11 @@ const checkPage = async (pageType, url) => {
 	await clearLocalStorage(page);
 	await clearCookies(page);
 	await reloadPage(page);
-	await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
+	await checkCMPIsOnPage(page, pageType);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'cookies and local storage cleared then page reloaded',
 	);
-	await checkCMPIsOnPage(page, pageType);
 	await checkTopAdDidNotLoad(page);
 	log(`[TEST 5] completed`);
 };

--- a/src/utils/cmp.js
+++ b/src/utils/cmp.js
@@ -1,6 +1,6 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const { TWO_SECONDS } = require('./constants');
+const { TWO_SECONDS, TEN_SECONDS } = require('./constants');
 const { log, logError } = require('./logging');
 
 const interactWithCMPTcfv2 = async (page) => {
@@ -76,7 +76,7 @@ const checkCMPIsOnPage = async (page, pageType) => {
 	log(`Waiting for CMP: Start`);
 	try {
 		await page.waitForSelector('[id*="sp_message_container"]', {
-			timeout: TWO_SECONDS,
+			timeout: TEN_SECONDS,
 		});
 	} catch (e) {
 		logError(`Could not find CMP: ${e.message}`);


### PR DESCRIPTION
## What are you changing?

- Increases timeout for checking if the CMP appears on the page
- Takes screenshots _after_ checking if the CMP is there rather than before
- Removes the two second waiting period before CMP presence checks

## Why?

The canary in Australia often fails because it hasn't loaded the CMP yet. This attempts to fix the issue
