### PR TITLE
Update Canary alarm description with new dashboard link

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -22,7 +22,7 @@ exports[`The CommercialCanaries stack matches the Australia CODE snapshot 1`] = 
           },
         ],
         "AlarmDescription": "Commercial canary is failing in ap-southeast-2.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -588,7 +588,7 @@ exports[`The CommercialCanaries stack matches the Australia PROD snapshot 1`] = 
           },
         ],
         "AlarmDescription": "Commercial canary is failing in ap-southeast-2.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -1154,7 +1154,7 @@ exports[`The CommercialCanaries stack matches the Canada CODE snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in ca-central-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -1720,7 +1720,7 @@ exports[`The CommercialCanaries stack matches the Canada PROD snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in ca-central-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -2286,7 +2286,7 @@ exports[`The CommercialCanaries stack matches the Europe CODE snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in eu-west-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -2852,7 +2852,7 @@ exports[`The CommercialCanaries stack matches the Europe PROD snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in eu-west-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -3418,7 +3418,7 @@ exports[`The CommercialCanaries stack matches the US CODE snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in us-west-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,
@@ -3984,7 +3984,7 @@ exports[`The CommercialCanaries stack matches the US PROD snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Commercial canary is failing in us-west-1.
-See https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details",
+See https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details",
         "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanThreshold",
         "DatapointsToAlarm": 5,

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -137,7 +137,7 @@ export class CommercialCanaries extends GuStack {
 		const alarm = new Alarm(this, 'Alarm', {
 			// Only allow alarm actions in PROD
 			actionsEnabled: stage === 'PROD',
-			alarmDescription: `Commercial canary is failing in ${env.region}.\nSee https://metrics.gutools.co.uk/d/degb6prp5nqpsc/canary-status for details`,
+			alarmDescription: `Commercial canary is failing in ${env.region}.\nSee https://metrics.gutools.co.uk/d/aej6crz3hvz0gc/canary-status for details`,
 			alarmName: `commercial-canary-${stage}`,
 			metric: alarmMetric,
 			/** Alarm is triggered if canary fails (or fails to run) 5 times in a row */


### PR DESCRIPTION
## What are you changing?

- Swaps the dashboard link in the canary alarm description

## Why?

- Since splitting the canary into two (front and article), the dashboard needed to be rebuilt to display both canaries
