### PR TITLE
Increase CMP timeouts

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -12,7 +12,7 @@ const {
 	interactWithCMPAus,
 } = require('./utils/cmp');
 const { setConfig } = require('./utils/config');
-const { TWO_SECONDS, TEN_SECONDS } = require('./utils/constants');
+const { TWO_SECONDS } = require('./utils/constants');
 const { log } = require('./utils/logging');
 const {
 	clearLocalStorage,
@@ -41,7 +41,6 @@ const testPage = async function () {
 	await synthetics.executeStep('[STEP 2] Check CMP', async function () {
 		log('Adverts load and the CMP is displayed on initial load');
 		await reloadPage(page);
-		await new Promise((r) => setTimeout(r, TEN_SECONDS)); // Wait an extra ten seconds after reloading the page
 		await synthetics.takeScreenshot(`cmp-${pageType}`, 'Page loaded');
 		await checkCMPIsOnPage(page, pageType);
 		await checkTopAdHasLoaded(page, pageType);
@@ -54,7 +53,6 @@ const testPage = async function () {
 		await interactWithCMPAus(page);
 		await checkCMPIsNotVisible(page);
 		await reloadPage(page);
-		await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 		await synthetics.takeScreenshot(
 			`cmp-${pageType}`,
 			'CMP clicked then page reloaded',

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -12,7 +12,6 @@ const {
 	interactWithCMPCcpa,
 } = require('./utils/cmp');
 const { setConfig } = require('./utils/config');
-const { TWO_SECONDS } = require('./utils/constants');
 const { log } = require('./utils/logging');
 const {
 	clearLocalStorage,
@@ -41,7 +40,6 @@ const testPage = async function () {
 	await synthetics.executeStep('[STEP 2] Check CMP', async function () {
 		log('CMP loads and the ads are NOT displayed on initial load');
 		await reloadPage(page);
-		await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 		await synthetics.takeScreenshot(`cmp-${pageType}`, 'Page loaded');
 		await checkCMPIsOnPage(page, pageType);
 		await checkTopAdHasLoaded(page, pageType);
@@ -54,7 +52,6 @@ const testPage = async function () {
 		await interactWithCMPCcpa(page);
 		await checkCMPIsNotVisible(page);
 		await reloadPage(page);
-		await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 		await synthetics.takeScreenshot(
 			`cmp-${pageType}`,
 			'CMP clicked then page reloaded',
@@ -72,7 +69,6 @@ const testPage = async function () {
 			await clearLocalStorage(page);
 			await clearCookies(page);
 			await reloadPage(page);
-			await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 			await synthetics.takeScreenshot(
 				`cmp-${pageType}`,
 				'cookies and local storage cleared then page reloaded',

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -43,7 +43,6 @@ const testPage = async function () {
 	await synthetics.executeStep('[STEP 2] Check CMP', async function () {
 		log('CMP loads and the ads are NOT displayed on initial load');
 		await reloadPage(page);
-		await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 		await synthetics.takeScreenshot(`cmp-${pageType}`, 'Page loaded');
 		await checkCMPIsOnPage(page, pageType);
 		await checkTopAdDidNotLoad(page);
@@ -65,7 +64,6 @@ const testPage = async function () {
 				'Adverts load and the CMP is NOT displayed when the page is reloaded',
 			);
 			await reloadPage(page);
-			await new Promise((r) => setTimeout(r, TWO_SECONDS)); // Wait an extra two seconds after reloading the page
 			await synthetics.takeScreenshot(
 				`cmp-${pageType}`,
 				'CMP clicked then page reloaded',

--- a/src/utils/page.js
+++ b/src/utils/page.js
@@ -1,4 +1,4 @@
-const { TEN_SECONDS } = require('./constants');
+const { TEN_SECONDS, TWO_SECONDS } = require('./constants');
 const { log, logError } = require('./logging');
 
 const clearCookies = async (page) => {
@@ -28,6 +28,8 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
+	// Wait an extra two seconds to allow the page to load
+	await new Promise((r) => setTimeout(r, TWO_SECONDS));
 	log(`Loading page: Complete`);
 };
 


### PR DESCRIPTION
## What are you changing?

- Adds extra two second wait after initial page load for consent frameworks in all regions
- Removes other additional waits after subsequent page reloads

## Why?

- We're seeing errors in the US and in AUS for timeouts related to finding or clicking on the CMP
