### PR TITLE
Bump CDK dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "commercial-canaries",
-  "version": "0.0.1",
-  "description": "repo to keep guardian's aws canaries",
-  "main": "index.js",
-  "repository": "git@github.com:guardian/commercial-canaries.git",
-  "license": "Apache-2.0",
-  "scripts": {
-    "build": "tsc",
-    "test": "jest --verbose",
-    "test-update": "jest -u",
-    "format": "prettier --write \"**/*.ts\"",
-    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
-    "synth": "cdk synth --path-metadata false --version-reporting false",
-    "diff": "cdk diff --path-metadata false --version-reporting false"
-  },
-  "devDependencies": {
-    "@guardian/cdk": "61.3.2",
-    "@guardian/eslint-config": "11.0.0",
-    "@guardian/prettier": "8.0.1",
-    "@types/jest": "29.5.14",
-    "@types/node": "22.13.11",
-    "aws-cdk": "2.1005.0",
-    "aws-cdk-lib": "2.187.0",
-    "eslint": "9.22.0",
-    "jest": "29.7.0",
-    "prettier": "3.5.3",
-    "ts-jest": "29.2.6",
-    "ts-node": "10.9.2",
-    "typescript": "5.7.2"
-  },
-  "packageManager": "pnpm@9.15.5"
+	"name": "commercial-canaries",
+	"version": "0.0.1",
+	"description": "repo to keep guardian's aws canaries",
+	"main": "index.js",
+	"repository": "git@github.com:guardian/commercial-canaries.git",
+	"license": "Apache-2.0",
+	"scripts": {
+		"build": "tsc",
+		"test": "jest --verbose",
+		"test-update": "jest -u",
+		"format": "prettier --write \"**/*.ts\"",
+		"lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+		"synth": "cdk synth --path-metadata false --version-reporting false",
+		"diff": "cdk diff --path-metadata false --version-reporting false"
+	},
+	"devDependencies": {
+		"@guardian/cdk": "61.4.0",
+		"@guardian/eslint-config": "11.0.0",
+		"@guardian/prettier": "8.0.1",
+		"@types/jest": "29.5.14",
+		"@types/node": "22.13.11",
+		"aws-cdk": "2.1007.0",
+		"aws-cdk-lib": "2.189.0",
+		"eslint": "9.22.0",
+		"jest": "29.7.0",
+		"prettier": "3.5.3",
+		"ts-jest": "29.2.6",
+		"ts-node": "10.9.2",
+		"typescript": "5.7.2"
+	},
+	"packageManager": "pnpm@9.15.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@guardian/cdk':
-        specifier: 61.3.2
-        version: 61.3.2(aws-cdk-lib@2.187.0(constructs@10.4.2))(aws-cdk@2.1005.0)(constructs@10.4.2)
+        specifier: 61.4.0
+        version: 61.4.0(aws-cdk-lib@2.189.0(constructs@10.4.2))(aws-cdk@2.1007.0)(constructs@10.4.2)
       '@guardian/eslint-config':
         specifier: 11.0.0
         version: 11.0.0(eslint-plugin-import@2.24.0(@typescript-eslint/parser@8.22.0(eslint@9.22.0)(typescript@5.7.2))(eslint@9.22.0))(eslint@9.22.0)(typescript@5.7.2)
@@ -24,11 +24,11 @@ importers:
         specifier: 22.13.11
         version: 22.13.11
       aws-cdk:
-        specifier: 2.1005.0
-        version: 2.1005.0
+        specifier: 2.1007.0
+        version: 2.1007.0
       aws-cdk-lib:
-        specifier: 2.187.0
-        version: 2.187.0(constructs@10.4.2)
+        specifier: 2.189.0
+        version: 2.189.0(constructs@10.4.2)
       eslint:
         specifier: 9.22.0
         version: 9.22.0
@@ -287,12 +287,12 @@ packages:
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@guardian/cdk@61.3.2':
-    resolution: {integrity: sha512-cK4zzISvDGRqF083WCDlWNXiV1lDehEt3tzl5Sbj1lKRMO7mMrTB1+4E9YKur7uoFiOxVQCxYnNzRkeb9qS9FA==}
+  '@guardian/cdk@61.4.0':
+    resolution: {integrity: sha512-HNlohcsDEDDVIkx/rznId/KlnEBEry0MDvJFOFUm7nJUKQI7SUlEQ6cg9ZSTjdl2i4iOGOVkl46Xq23B0UW6wQ==}
     hasBin: true
     peerDependencies:
-      aws-cdk: 2.1005.0
-      aws-cdk-lib: 2.185.0
+      aws-cdk: 2.1007.0
+      aws-cdk-lib: 2.189.0
       constructs: 10.4.2
 
   '@guardian/eslint-config@11.0.0':
@@ -710,8 +710,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.187.0:
-    resolution: {integrity: sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==}
+  aws-cdk-lib@2.189.0:
+    resolution: {integrity: sha512-B5Uha7uRntOAyuKfU0eFtxij3ZVTzGAbetw5qaXlURa68wsWpKlU72/OyKugB6JYkhjCZkSTVVBxd1pVTosxEw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -728,8 +728,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.1005.0:
-    resolution: {integrity: sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==}
+  aws-cdk@2.1007.0:
+    resolution: {integrity: sha512-/UOYOTGWUm+pP9qxg03tID5tL6euC+pb+xo0RBue+xhnUWwj/Bbsw6DbqbpOPMrNzTUxmM723/uMEQmM6S26dw==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -870,8 +870,8 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
-  codemaker@1.110.0:
-    resolution: {integrity: sha512-+aIsH91DjT+c0fDG0CqELCpeZJZyj6Lw266B3iLivBOZvJabdP+myoNLdIqCwcUkp0q17MFL27tilWIhy1DuuQ==}
+  codemaker@1.111.0:
+    resolution: {integrity: sha512-roT0x2rjngWUTbyM/mFyLSkh/H8YMZlaj7kSLzzJAZUSLxRjU/4zPd0bvjaRERVONJZMlitrP8ndmqnEjxLoBw==}
     engines: {node: '>= 14.17.0'}
 
   collect-v8-coverage@1.0.2:
@@ -2962,14 +2962,14 @@ snapshots:
       '@eslint/core': 0.12.0
       levn: 0.4.1
 
-  '@guardian/cdk@61.3.2(aws-cdk-lib@2.187.0(constructs@10.4.2))(aws-cdk@2.1005.0)(constructs@10.4.2)':
+  '@guardian/cdk@61.4.0(aws-cdk-lib@2.189.0(constructs@10.4.2))(aws-cdk@2.1007.0)(constructs@10.4.2)':
     dependencies:
       '@oclif/core': 3.26.6
-      aws-cdk: 2.1005.0
-      aws-cdk-lib: 2.187.0(constructs@10.4.2)
+      aws-cdk: 2.1007.0
+      aws-cdk-lib: 2.189.0(constructs@10.4.2)
       aws-sdk: 2.1692.0
       chalk: 4.1.2
-      codemaker: 1.110.0
+      codemaker: 1.111.0
       constructs: 10.4.2
       git-url-parse: 16.0.1
       js-yaml: 4.1.0
@@ -3593,14 +3593,14 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-cdk-lib@2.187.0(constructs@10.4.2):
+  aws-cdk-lib@2.189.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.230
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
       '@aws-cdk/cloud-assembly-schema': 41.2.0
       constructs: 10.4.2
 
-  aws-cdk@2.1005.0:
+  aws-cdk@2.1007.0:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -3779,7 +3779,7 @@ snapshots:
 
   co@4.6.0: {}
 
-  codemaker@1.110.0:
+  codemaker@1.111.0:
     dependencies:
       camelcase: 6.3.0
       decamelize: 5.0.1


### PR DESCRIPTION
## What are you changing?

- Bumps version of `@guardian/cdk`, `aws-cdk` and `aws-cdk-lib`

## Why?

- Keeping dependencies up to date
