### PR TITLE
Extend Prebid - `window.pbjs` to 3 seconds

### DIFF
--- a/src/utils/adverts.js
+++ b/src/utils/adverts.js
@@ -71,7 +71,7 @@ const checkPbjsPresence = async (page) => {
 			() =>
 				// eslint-disable-next-line no-undef -- window object exists in the browser only
 				window.pbjs !== undefined,
-			{ timeout: secondsInMillis(2) },
+			{ timeout: secondsInMillis(3) },
 		);
 	} catch (timeoutError) {
 		logError('Prebid.js is not loaded');


### PR DESCRIPTION
## What are you changing?

- This PR extends the Prebid presence on window to 3 seconds so we could investigate if the EU canary is failing on step 7 `Prebid - window.pbjs` due to being slow or it's a different issue. 

## Why?

- Investigating the alarms in `eu-west-1` fronts canary. 
